### PR TITLE
Add fallback similarity implementation and refresh setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,18 @@
 1. **安装依赖**
 
    ```bash
-   python -m venv .venv
+   python3 -m venv .venv
    source .venv/bin/activate  # Windows 使用 .venv\Scripts\activate
-   pip install -r requirements.txt
+   python -m pip install --upgrade pip
+   python -m pip install -r requirements.txt
+   ```
+
+   > 💡 为避免 `python`、`pip` 与 `flask` 指向不同解释器，请始终通过 `python -m ...` 的形式安装依赖和启动服务。
+
+   如需启用 BERT 语义模型，可额外安装（如当前 Python 版本支持）：
+
+   ```bash
+   python -m pip install sentence-transformers numpy scipy
    ```
 
 2. **配置 SMTP**
@@ -42,7 +51,7 @@
 3. **启动服务**
 
    ```bash
-   flask --app app run
+   python -m flask --app app run
    ```
 
    首次启动会自动初始化数据库并启动监控调度器。
@@ -61,7 +70,7 @@
 
 ## 注意事项
 
-- `sentence-transformers` 首次运行会下载预训练模型，需要能够访问 HuggingFace Hub。
+- 若未安装 `sentence-transformers`（例如在暂不提供相应轮子的 Python 3.13 环境），系统会回退到内置的模糊匹配算法，依然可以正常运行，只是相似度精度略低。若之后补充安装了 `sentence-transformers`，重新启动服务即可自动启用语义模型。
 - 如果站点页面结构复杂，可根据实际情况在 `crawler.py` 中扩展解析与差异检测逻辑。
 - 默认示例 SMTP 配置仅为占位，请务必使用真实的邮件服务账号。
 

--- a/nlp.py
+++ b/nlp.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
 
+import logging
+from difflib import SequenceMatcher
 from functools import lru_cache
 from typing import Iterable
 
-import numpy as np
-from sentence_transformers import SentenceTransformer
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+try:
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - optional dependency
+    SentenceTransformer = None  # type: ignore[misc,assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+_FALLBACK_NOTICE_EMITTED = False
 
 
 @lru_cache(maxsize=1)
-def get_model() -> SentenceTransformer:
-    """Load and cache the sentence transformer model."""
+def get_model() -> SentenceTransformer | None:
+    """Load and cache the sentence transformer model if available."""
+
+    if SentenceTransformer is None:
+        return None
     return SentenceTransformer("all-MiniLM-L6-v2")
 
 
-def cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+def cosine_similarity(vec_a: "np.ndarray", vec_b: "np.ndarray") -> float:
     denom = np.linalg.norm(vec_a) * np.linalg.norm(vec_b)
     if denom == 0:
         return 0.0
@@ -22,6 +38,20 @@ def cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
 
 def similarity(text: str, candidates: Iterable[str]) -> list[float]:
     model = get_model()
+    if not candidates:
+        return []
+
+    if model is None or np is None:
+        global _FALLBACK_NOTICE_EMITTED
+        if not _FALLBACK_NOTICE_EMITTED:
+            LOGGER.warning(
+                "sentence-transformers not available; falling back to basic text similarity."
+            )
+            _FALLBACK_NOTICE_EMITTED = True
+
+        baseline = text.lower()
+        return [SequenceMatcher(None, baseline, candidate.lower()).ratio() for candidate in candidates]
+
     sentences = [text, *candidates]
     embeddings = model.encode(sentences, convert_to_numpy=True, normalize_embeddings=False)
     base_vec = embeddings[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-Flask==2.3.3
-SQLAlchemy==2.0.23
-requests==2.31.0
-beautifulsoup4==4.12.2
-sentence-transformers==2.2.2
-numpy==1.26.2
-scipy==1.11.3
+Flask>=3.1.0
+SQLAlchemy>=2.0.23
+requests>=2.31.0
+beautifulsoup4>=4.12.2
+
+# 以下依赖仅在使用语义相似度模型时需要，Python 3.13 环境可选择跳过
+sentence-transformers>=2.2.2; python_version < "3.13"
+numpy>=1.26.2; python_version < "3.13"
+scipy>=1.11.3; python_version < "3.13"


### PR DESCRIPTION
## Summary
- allow the NLP helper to fall back to a lightweight fuzzy matcher when sentence-transformers or NumPy are unavailable
- refresh dependency pins to support Python 3.13 environments while keeping semantic extras optional
- expand the README with interpreter-aligned setup and launch instructions plus notes about the optional semantic model

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dc98fe7ac88320878bde17b5b38e39