### PR TITLE
feat: add notification management and DingTalk alerts

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -9,7 +9,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from database import SessionLocal
-from email_utils import send_email
+from email_utils import NotificationConfigError, send_dingtalk_message, send_email
 from models import CrawlLog, CrawlResult, MonitorTask, WatchContent
 from nlp import similarity
 
@@ -64,12 +64,13 @@ def score_contents(article_summary: str, contents: Iterable[WatchContent]) -> li
     return list(zip(contents, scores))
 
 
-def notify(task: MonitorTask, title: str, url: str, summary: str, matches: list[tuple[WatchContent, float]]) -> None:
-    recipient = task.notification_email
-    if not recipient:
-        LOGGER.warning("Task %s has no notification email", task.id)
-        return
-
+def notify(
+    task: MonitorTask,
+    title: str,
+    url: str,
+    summary: str,
+    matches: list[tuple[WatchContent, float]],
+) -> None:
     rows = "".join(
         f"<li><strong>{content.text}</strong> - 相似度: {score:.2f}</li>" for content, score in matches
     )
@@ -82,7 +83,42 @@ def notify(task: MonitorTask, title: str, url: str, summary: str, matches: list[
         <p><strong>摘要:</strong> {summary}</p>
     """
     text_body = f"监控任务 {task.name} 发现匹配内容: {title or '未提供'} - {url}\n摘要: {summary}"
-    send_email(subject=f"监控任务 {task.name} 有新内容", recipients=[recipient], html_body=html_body, text_body=text_body)
+
+    if task.notification_method == "dingtalk":
+        markdown_rows = "\n".join(
+            f"- **{content.text}** 相似度：{score:.2f}" for content, score in matches
+        )
+        markdown = (
+            f"### 监控任务：{task.name}\n"
+            f"发现新的内容匹配关注项：\n{markdown_rows}\n\n"
+            f"**标题：** {title or '未提供'}\n\n"
+            f"**链接：** {url}\n\n"
+            f"**摘要：** {summary}"
+        )
+        try:
+            send_dingtalk_message(title=f"监控任务 {task.name} 有新内容", markdown=markdown)
+        except NotificationConfigError:
+            LOGGER.warning("钉钉通知配置缺失，任务 %s 无法发送", task.id)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("任务 %s 发送钉钉通知失败", task.id)
+        return
+
+    recipients = [email.strip() for email in (task.notification_email or "").split(",") if email.strip()]
+    if not recipients:
+        LOGGER.warning("Task %s has no notification email", task.id)
+        return
+
+    try:
+        send_email(
+            subject=f"监控任务 {task.name} 有新内容",
+            recipients=recipients,
+            html_body=html_body,
+            text_body=text_body,
+        )
+    except NotificationConfigError:
+        LOGGER.warning("邮件通知配置缺失，任务 %s 无法发送", task.id)
+    except Exception:  # noqa: BLE001
+        LOGGER.exception("任务 %s 发送邮件失败", task.id)
 
 
 def run_task(task_id: int) -> None:

--- a/email_utils.py
+++ b/email_utils.py
@@ -2,15 +2,30 @@ from __future__ import annotations
 
 import os
 import smtplib
+from dataclasses import dataclass
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Iterable
 
+import requests
 from flask import current_app
 
+from database import SessionLocal
+from models import NotificationSetting
 
-class EmailConfigError(RuntimeError):
+
+class NotificationConfigError(RuntimeError):
     pass
+
+
+@dataclass
+class EmailSettings:
+    host: str
+    port: int
+    username: str
+    password: str
+    use_tls: bool
+    sender: str
 
 
 def _get_setting(name: str, default: str | None = None) -> str:
@@ -19,20 +34,77 @@ def _get_setting(name: str, default: str | None = None) -> str:
         return value
     if default is not None:
         return default
-    raise EmailConfigError(f"Missing email configuration: {name}")
+    raise NotificationConfigError(f"Missing configuration: {name}")
 
 
-def send_email(subject: str, recipients: Iterable[str], html_body: str, text_body: str | None = None) -> None:
+def _load_email_settings() -> EmailSettings:
+    session = SessionLocal()
+    try:
+        setting = (
+            session.query(NotificationSetting)
+            .filter(NotificationSetting.channel == "email")
+            .one_or_none()
+        )
+    finally:
+        session.close()
+
+    if setting and setting.smtp_host and setting.smtp_username and setting.smtp_password:
+        sender = setting.smtp_sender or setting.smtp_username
+        return EmailSettings(
+            host=setting.smtp_host,
+            port=setting.smtp_port or 587,
+            username=setting.smtp_username,
+            password=setting.smtp_password,
+            use_tls=bool(setting.smtp_use_tls),
+            sender=sender,
+        )
+
     host = _get_setting("SMTP_HOST")
     port = int(_get_setting("SMTP_PORT", "587"))
     username = _get_setting("SMTP_USERNAME")
     password = _get_setting("SMTP_PASSWORD")
     use_tls = _get_setting("SMTP_USE_TLS", "true").lower() != "false"
     sender = _get_setting("SMTP_SENDER", username)
+    return EmailSettings(
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        use_tls=use_tls,
+        sender=sender,
+    )
+
+
+def _get_dingtalk_webhook() -> str:
+    session = SessionLocal()
+    try:
+        setting = (
+            session.query(NotificationSetting)
+            .filter(NotificationSetting.channel == "dingtalk")
+            .one_or_none()
+        )
+    finally:
+        session.close()
+
+    if setting and setting.webhook_url:
+        return setting.webhook_url
+    value = os.getenv("DINGTALK_WEBHOOK")
+    if value:
+        return value
+    raise NotificationConfigError("Missing DingTalk webhook configuration")
+
+
+def send_email(
+    subject: str,
+    recipients: Iterable[str],
+    html_body: str,
+    text_body: str | None = None,
+) -> None:
+    settings = _load_email_settings()
 
     message = MIMEMultipart("alternative")
     message["Subject"] = subject
-    message["From"] = sender
+    message["From"] = settings.sender
     message["To"] = ", ".join(recipients)
 
     if text_body is None:
@@ -41,8 +113,21 @@ def send_email(subject: str, recipients: Iterable[str], html_body: str, text_bod
     message.attach(MIMEText(text_body, "plain", "utf-8"))
     message.attach(MIMEText(html_body, "html", "utf-8"))
 
-    with smtplib.SMTP(host, port) as server:
-        if use_tls:
+    with smtplib.SMTP(settings.host, settings.port) as server:
+        if settings.use_tls:
             server.starttls()
-        server.login(username, password)
-        server.sendmail(sender, recipients, message.as_string())
+        server.login(settings.username, settings.password)
+        server.sendmail(settings.sender, recipients, message.as_string())
+
+
+def send_dingtalk_message(title: str, markdown: str) -> None:
+    webhook_url = _get_dingtalk_webhook()
+    payload = {
+        "msgtype": "markdown",
+        "markdown": {
+            "title": title,
+            "text": markdown,
+        },
+    }
+    response = requests.post(webhook_url, json=payload, timeout=10)
+    response.raise_for_status()

--- a/models.py
+++ b/models.py
@@ -61,7 +61,8 @@ class MonitorTask(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     website_id: Mapped[int] = mapped_column(ForeignKey("websites.id"), nullable=False)
-    notification_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    notification_method: Mapped[str] = mapped_column(String(50), default="email")
+    notification_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_status: Mapped[str | None] = mapped_column(String(50), nullable=True)
@@ -86,6 +87,21 @@ class MonitorTask(Base):
         cascade="all, delete-orphan",
         order_by="desc(CrawlResult.created_at)",
     )
+
+
+class NotificationSetting(Base):
+    __tablename__ = "notification_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    channel: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    smtp_host: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    smtp_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    smtp_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    smtp_password: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    smtp_use_tls: Mapped[bool] = mapped_column(Boolean, default=True)
+    smtp_sender: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    webhook_url: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 
 class CrawlLog(Base):

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@
           <a class="nav-link" href="{{ url_for('list_contents') }}">关注内容</a>
           <a class="nav-link" href="{{ url_for('list_tasks') }}">监控任务</a>
           <a class="nav-link" href="{{ url_for('list_results') }}">监控记录</a>
+          <a class="nav-link" href="{{ url_for('manage_notifications') }}">通知配置</a>
         </div>
       </div>
     </nav>

--- a/templates/notifications/manage.html
+++ b/templates/notifications/manage.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>通知配置</h2>
+<p class="text-muted">在此管理邮件和钉钉通知的全局配置，供监控任务使用。</p>
+<div class="row">
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header">SMTP 邮件配置</div>
+      <div class="card-body">
+        <form method="post">
+          <input type="hidden" name="config_type" value="email">
+          <div class="mb-3">
+            <label class="form-label">SMTP 主机</label>
+            <input type="text" class="form-control" name="smtp_host" value="{{ email_setting.smtp_host if email_setting else '' }}" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">SMTP 端口</label>
+            <input type="number" class="form-control" name="smtp_port" value="{{ email_setting.smtp_port if email_setting and email_setting.smtp_port else 587 }}" min="1">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">用户名</label>
+            <input type="text" class="form-control" name="smtp_username" value="{{ email_setting.smtp_username if email_setting else '' }}" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">密码 / 授权码</label>
+            <input type="password" class="form-control" name="smtp_password" value="{{ email_setting.smtp_password if email_setting else '' }}" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">发件人地址</label>
+            <input type="email" class="form-control" name="smtp_sender" value="{{ email_setting.smtp_sender if email_setting else '' }}">
+            <div class="form-text">若为空则默认使用用户名。</div>
+          </div>
+          <div class="form-check form-switch mb-3">
+            <input class="form-check-input" type="checkbox" id="smtpUseTls" name="smtp_use_tls" {% if not email_setting or email_setting.smtp_use_tls %}checked{% endif %}>
+            <label class="form-check-label" for="smtpUseTls">启用 TLS</label>
+          </div>
+          <button class="btn btn-primary" type="submit">保存 SMTP 配置</button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mb-4">
+      <div class="card-header">钉钉机器人配置</div>
+      <div class="card-body">
+        <form method="post">
+          <input type="hidden" name="config_type" value="dingtalk">
+          <div class="mb-3">
+            <label class="form-label">Webhook 地址</label>
+            <input type="url" class="form-control" name="webhook_url" value="{{ dingtalk_setting.webhook_url if dingtalk_setting else '' }}" required>
+          </div>
+          <div class="form-text mb-3">请使用钉钉群机器人提供的自定义机器人 webhook 地址。</div>
+          <button class="btn btn-primary" type="submit">保存钉钉配置</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -7,7 +7,16 @@
     <span class="badge text-bg-secondary">{{ content.text }}</span>
   {% endfor %}
 </p>
-<p><strong>通知邮箱：</strong> {{ task.notification_email }}</p>
+<p><strong>通知方式：</strong>
+  {% if task.notification_method == 'dingtalk' %}
+    钉钉群机器人
+  {% else %}
+    邮件
+  {% endif %}
+</p>
+{% if task.notification_method == 'email' %}
+<p><strong>通知邮箱：</strong> {{ task.notification_email or '未配置' }}</p>
+{% endif %}
 <p><strong>任务状态：</strong> {{ '运行中' if task.is_active else '已暂停' }}，最近状态：{{ task.last_status or '无' }}</p>
 <p><strong>相似度阈值：</strong> {{ threshold }}</p>
 

--- a/templates/tasks/form.html
+++ b/templates/tasks/form.html
@@ -1,23 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>新增监控任务</h2>
+{% set is_edit = task is not none %}
+<h2>{{ '编辑监控任务' if is_edit else '新增监控任务' }}</h2>
 <form method="post" class="mt-3">
   <div class="mb-3">
     <label class="form-label">任务名称</label>
-    <input type="text" class="form-control" name="name" required>
+    <input type="text" class="form-control" name="name" value="{{ form_data.get('name', '') }}" required>
   </div>
   <div class="mb-3">
     <label class="form-label">选择网站</label>
     <select class="form-select" name="website_id" required>
       <option value="">请选择</option>
       {% for website in websites %}
-        <option value="{{ website.id }}">{{ website.name }} ({{ website.interval_minutes }}分钟)</option>
+        {% set selected = form_data.get('website_id') %}
+        <option value="{{ website.id }}" {% if selected == website.id %}selected{% endif %}>{{ website.name }} ({{ website.interval_minutes }}分钟)</option>
       {% endfor %}
     </select>
   </div>
   <div class="mb-3">
+    <label class="form-label">通知方式</label>
+    {% set current_method = form_data.get('notification_method', 'email') %}
+    <select class="form-select" name="notification_method" id="notificationMethod">
+      <option value="email" {% if current_method == 'email' %}selected{% endif %}>邮件</option>
+      <option value="dingtalk" {% if current_method == 'dingtalk' %}selected{% endif %}>钉钉</option>
+    </select>
+  </div>
+  <div class="mb-3" id="emailGroup">
     <label class="form-label">通知邮箱</label>
-    <input type="email" class="form-control" name="notification_email" required>
+    <input type="text" class="form-control" name="notification_email" value="{{ form_data.get('notification_email', '') }}" {% if current_method != 'email' %}disabled{% endif %}>
+    <div class="form-text">多个邮箱请使用逗号或分号分隔。</div>
   </div>
   <div class="mb-3">
     <label class="form-label">选择关注内容（可多选）</label>
@@ -25,7 +36,7 @@
       {% for content in contents %}
       <div class="col-md-4">
         <div class="form-check">
-          <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids">
+          <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids" {% if content.id in selected_content_ids %}checked{% endif %}>
           <label class="form-check-label" for="content{{ content.id }}">{{ content.text }}</label>
         </div>
       </div>
@@ -41,4 +52,18 @@
 {% if not contents %}
 <p class="text-muted">请先添加关注内容。</p>
 {% endif %}
+<script>
+  const methodSelect = document.getElementById('notificationMethod');
+  const emailGroup = document.getElementById('emailGroup');
+  const emailInput = emailGroup.querySelector('input[name="notification_email"]');
+
+  function toggleEmailField() {
+    const isEmail = methodSelect.value === 'email';
+    emailGroup.style.display = isEmail ? 'block' : 'none';
+    emailInput.disabled = !isEmail;
+  }
+
+  methodSelect.addEventListener('change', toggleEmailField);
+  toggleEmailField();
+</script>
 {% endblock %}

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -10,7 +10,8 @@
       <th>名称</th>
       <th>网站</th>
       <th>关注内容</th>
-      <th>通知邮箱</th>
+      <th>通知方式</th>
+      <th>通知配置</th>
       <th>最后执行</th>
       <th>状态</th>
       <th>操作</th>
@@ -26,10 +27,18 @@
           <span class="badge text-bg-secondary">{{ content.text }}</span>
         {% endfor %}
       </td>
-      <td>{{ task.notification_email }}</td>
+      <td>{% if task.notification_method == 'dingtalk' %}钉钉{% else %}邮件{% endif %}</td>
+      <td>
+        {% if task.notification_method == 'dingtalk' %}
+          钉钉群机器人
+        {% else %}
+          {{ task.notification_email or '未配置' }}
+        {% endif %}
+      </td>
       <td>{{ task.last_run_at or '尚未执行' }}</td>
       <td>{{ '运行中' if task.is_active else '已暂停' }} / {{ task.last_status or '未执行' }}</td>
       <td>
+        <a class="btn btn-sm btn-info" href="{{ url_for('edit_task', task_id=task.id) }}">编辑</a>
         <form action="{{ url_for('toggle_task', task_id=task.id) }}" method="post" class="d-inline">
           <button class="btn btn-sm btn-warning">{{ '暂停' if task.is_active else '启动' }}</button>
         </form>


### PR DESCRIPTION
## Summary
- add a notification management page to maintain SMTP and DingTalk webhook settings in the database
- allow monitor tasks to choose email or DingTalk delivery and edit existing tasks with the updated form
- send notifications through the configured channel, including new DingTalk markdown messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcda31c1048320a39ebfcdab4b032b