### PR TITLE
Add content category management with bulk editing

### DIFF
--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -41,12 +42,33 @@ class Website(Base):
     tasks: Mapped[List["MonitorTask"]] = relationship("MonitorTask", back_populates="website")
 
 
-class WatchContent(Base):
-    __tablename__ = "watch_contents"
+class ContentCategory(Base):
+    __tablename__ = "content_categories"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    text: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    contents: Mapped[List["WatchContent"]] = relationship(
+        "WatchContent",
+        back_populates="category",
+        cascade="all, delete-orphan",
+        order_by="WatchContent.created_at.desc()",
+    )
+
+
+class WatchContent(Base):
+    __tablename__ = "watch_contents"
+    __table_args__ = (
+        UniqueConstraint("category_id", "text", name="uq_content_category_text"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    text: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    category_id: Mapped[int] = mapped_column(ForeignKey("content_categories.id"), nullable=False)
+
+    category: Mapped[ContentCategory] = relationship("ContentCategory", back_populates="contents")
 
     tasks: Mapped[List["MonitorTask"]] = relationship(
         "MonitorTask",
@@ -117,3 +139,5 @@ class CrawlResult(Base):
     task: Mapped[MonitorTask] = relationship("MonitorTask", back_populates="results")
     website: Mapped[Website] = relationship("Website")
     content: Mapped[WatchContent | None] = relationship("WatchContent")
+
+

--- a/templates/contents/bulk_edit.html
+++ b/templates/contents/bulk_edit.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>批量编辑「{{ category.name }}」关注内容</h2>
+<form method="post" class="mt-3">
+  <div class="mb-3">
+    <label class="form-label">一行一条关注内容（最多50个字符）</label>
+    <textarea class="form-control" name="bulk_text" rows="12" placeholder="请输入关注内容，每行一条">{{ bulk_text }}</textarea>
+    <div class="form-text">提交后将覆盖该分类下的关注内容列表，空白行会被忽略。</div>
+  </div>
+  <button class="btn btn-primary" type="submit">保存</button>
+  <a class="btn btn-secondary" href="{{ url_for('list_contents', category_id=category.id) }}">返回</a>
+</form>
+{% endblock %}

--- a/templates/contents/form.html
+++ b/templates/contents/form.html
@@ -6,7 +6,20 @@
     <label class="form-label">关注内容（最多50个字符）</label>
     <input type="text" class="form-control" name="text" maxlength="50" required>
   </div>
-  <button class="btn btn-primary" type="submit">保存</button>
+  <div class="mb-3">
+    <label class="form-label">所属分类</label>
+    {% if categories %}
+    <select class="form-select" name="category_id" required>
+      <option value="">请选择分类</option>
+      {% for category in categories %}
+      <option value="{{ category.id }}" {% if selected_category_id == category.id %}selected{% endif %}>{{ category.name }}</option>
+      {% endfor %}
+    </select>
+    {% else %}
+    <div class="alert alert-info mb-0">当前尚未创建分类，请先返回列表新增分类后再添加关注内容。</div>
+    {% endif %}
+  </div>
+  <button class="btn btn-primary" type="submit" {% if not categories %}disabled{% endif %}>保存</button>
   <a class="btn btn-secondary" href="{{ url_for('list_contents') }}">返回</a>
 </form>
 {% endblock %}

--- a/templates/contents/list.html
+++ b/templates/contents/list.html
@@ -1,29 +1,86 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="d-flex justify-content-between align-items-center mb-3">
-  <h2>关注内容清单</h2>
-  <a href="{{ url_for('create_content') }}" class="btn btn-primary">新增关注内容</a>
+<div class="d-flex flex-wrap gap-2 align-items-center mb-3">
+  <h2 class="mb-0">关注内容清单</h2>
+  {% if selected_category %}
+  <a href="{{ url_for('bulk_edit_category_contents', category_id=selected_category.id) }}" class="btn btn-outline-secondary btn-sm">批量编辑「{{ selected_category.name }}」</a>
+  {% endif %}
+  {% if categories %}
+  <a href="{{ url_for('create_content', category_id=selected_category.id if selected_category else None) }}" class="btn btn-primary ms-auto">新增关注内容</a>
+  {% else %}
+  <span class="text-muted ms-auto">请先创建分类</span>
+  {% endif %}
 </div>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>关注内容</th>
-      <th>创建时间</th>
-      <th>操作</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for content in contents %}
-    <tr>
-      <td>{{ content.text }}</td>
-      <td>{{ content.created_at }}</td>
-      <td>
-        <form action="{{ url_for('delete_content', content_id=content.id) }}" method="post" onsubmit="return confirm('确认删除该关注内容？');">
-          <button class="btn btn-sm btn-danger">删除</button>
-        </form>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+
+<div class="card mb-4">
+  <div class="card-header">新增分类</div>
+  <div class="card-body">
+    <form class="row row-cols-lg-auto g-2 align-items-center" method="post" action="{{ url_for('create_content_category') }}">
+      <div class="col">
+        <label for="categoryName" class="visually-hidden">分类名称</label>
+        <input type="text" class="form-control" id="categoryName" name="name" placeholder="请输入分类名称" required>
+      </div>
+      <div class="col">
+        <button class="btn btn-success" type="submit">保存分类</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="d-flex flex-wrap gap-2 mb-4">
+  <a class="btn btn-outline-primary {% if not selected_category %}active{% endif %}" href="{{ url_for('list_contents') }}">全部 <span class="badge text-bg-secondary ms-1">{{ total_count }}</span></a>
+  {% for category in categories %}
+  <div class="btn-group">
+    <a class="btn btn-outline-primary {% if selected_category_id == category.id %}active{% endif %}" href="{{ url_for('list_contents', category_id=category.id) }}">
+      {{ category.name }}
+      <span class="badge text-bg-secondary ms-1">{{ category.contents|length }}</span>
+    </a>
+    <form method="post" action="{{ url_for('delete_content_category', category_id=category.id) }}" onsubmit="return confirm('确认删除该分类？删除前需清空分类下的关注内容。');">
+      <button class="btn btn-outline-primary text-danger" type="submit" title="删除分类">&times;</button>
+    </form>
+  </div>
+  {% endfor %}
+</div>
+
+<div class="card">
+  <div class="card-header">
+    {% if selected_category %}
+      「{{ selected_category.name }}」分类下的关注内容
+    {% else %}
+      全部关注内容
+    {% endif %}
+  </div>
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-striped mb-0">
+        <thead>
+          <tr>
+            <th scope="col">关注内容</th>
+            <th scope="col">分类</th>
+            <th scope="col">创建时间</th>
+            <th scope="col">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for content in contents %}
+          <tr>
+            <td>{{ content.text }}</td>
+            <td>{{ content.category.name }}</td>
+            <td>{{ content.created_at }}</td>
+            <td>
+              <form action="{{ url_for('delete_content', content_id=content.id) }}" method="post" onsubmit="return confirm('确认删除该关注内容？');">
+                <button class="btn btn-sm btn-danger">删除</button>
+              </form>
+            </td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="4" class="text-center text-muted py-4">当前分类下暂无关注内容</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/templates/results/list.html
+++ b/templates/results/list.html
@@ -24,8 +24,14 @@
     <label class="form-label">关注内容</label>
     <select class="form-select" name="content_id">
       <option value="">全部</option>
-      {% for content in contents %}
-      <option value="{{ content.id }}" {% if query_args.content_id == content.id|string %}selected{% endif %}>{{ content.text }}</option>
+      {% for category in categories %}
+        {% if category.contents %}
+        <optgroup label="{{ category.name }}">
+          {% for content in category.contents %}
+          <option value="{{ content.id }}" {% if query_args.content_id == content.id|string %}selected{% endif %}>{{ content.text }}</option>
+          {% endfor %}
+        </optgroup>
+        {% endif %}
       {% endfor %}
     </select>
   </div>
@@ -59,7 +65,14 @@
       <td>{{ result.created_at }}</td>
       <td>{{ result.task.name }}</td>
       <td>{{ result.website.name }}</td>
-      <td>{{ result.content.text if result.content else '未知' }}</td>
+      <td>
+        {% if result.content %}
+          <div>{{ result.content.text }}</div>
+          <small class="text-muted">分类：{{ result.content.category.name if result.content.category else '未分类' }}</small>
+        {% else %}
+          未知
+        {% endif %}
+      </td>
       <td>{{ result.link_title or '无标题' }}</td>
       <td><a href="{{ result.discovered_url }}" target="_blank">打开</a></td>
       <td>{{ '%.2f'|format(result.similarity_score or 0) }}</td>

--- a/templates/tasks/form.html
+++ b/templates/tasks/form.html
@@ -21,16 +21,32 @@
   </div>
   <div class="mb-3">
     <label class="form-label">选择关注内容（可多选）</label>
-    <div class="row">
-      {% for content in contents %}
-      <div class="col-md-4">
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids">
-          <label class="form-check-label" for="content{{ content.id }}">{{ content.text }}</label>
+    {% if categories %}
+      {% for category in categories %}
+      <div class="border rounded p-3 mb-3">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h6 class="mb-0">{{ category.name }}</h6>
+          <a class="small" href="{{ url_for('bulk_edit_category_contents', category_id=category.id) }}">批量编辑</a>
         </div>
+        {% if category.contents %}
+        <div class="row g-2">
+          {% for content in category.contents %}
+          <div class="col-md-6 col-lg-4">
+            <div class="form-check">
+              <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids">
+              <label class="form-check-label" for="content{{ content.id }}">{{ content.text }}</label>
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+        {% else %}
+        <p class="text-muted mb-0 small">该分类下暂无关注内容。</p>
+        {% endif %}
       </div>
       {% endfor %}
-    </div>
+    {% else %}
+    <p class="text-muted mb-0">请先在关注内容清单中创建分类并添加内容。</p>
+    {% endif %}
   </div>
   <button class="btn btn-primary" type="submit">保存</button>
   <a class="btn btn-secondary" href="{{ url_for('list_tasks') }}">返回</a>
@@ -38,7 +54,7 @@
 {% if not websites %}
 <p class="text-muted mt-3">请先配置关注网站。</p>
 {% endif %}
-{% if not contents %}
-<p class="text-muted">请先添加关注内容。</p>
+{% if not has_contents %}
+<p class="text-muted">请先在关注内容清单中维护分类及关注内容。</p>
 {% endif %}
 {% endblock %}

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -23,7 +23,7 @@
       <td>{{ task.website.name if task.website else '未配置' }}</td>
       <td>
         {% for content in task.watch_contents %}
-          <span class="badge text-bg-secondary">{{ content.text }}</span>
+          <span class="badge text-bg-secondary">{{ content.category.name if content.category else '未分类' }}：{{ content.text }}</span>
         {% endfor %}
       </td>
       <td>{{ task.notification_email }}</td>

--- a/tests/test_content_categories.py
+++ b/tests/test_content_categories.py
@@ -1,0 +1,71 @@
+import unittest
+from pathlib import Path
+
+from database import Base, SessionLocal, engine
+import app
+from models import ContentCategory, WatchContent
+
+
+class ContentCategoryRoutesTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = Path("data.db")
+        if self.db_path.exists():
+            self.db_path.unlink()
+        Base.metadata.create_all(bind=engine)
+        self.original_setup_flag = app._setup_complete
+        app._setup_complete = True
+        app.app.testing = True
+        self.client = app.app.test_client()
+
+    def tearDown(self) -> None:
+        SessionLocal.remove()
+        Base.metadata.drop_all(bind=engine)
+        if self.db_path.exists():
+            self.db_path.unlink()
+        app._setup_complete = self.original_setup_flag
+
+    def test_bulk_edit_replaces_category_contents(self) -> None:
+        response = self.client.post(
+            "/content-categories",
+            data={"name": "政策解读"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        session = SessionLocal()
+        category = session.query(ContentCategory).filter_by(name="政策解读").one()
+        session.close()
+
+        response = self.client.post(
+            f"/content-categories/{category.id}/bulk",
+            data={"bulk_text": "宏观政策\n产业规划"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        session = SessionLocal()
+        contents = (
+            session.query(WatchContent)
+            .filter(WatchContent.category_id == category.id)
+            .order_by(WatchContent.text)
+            .all()
+        )
+        session.close()
+        self.assertEqual([item.text for item in contents], ["产业规划", "宏观政策"])
+
+        response = self.client.post(
+            f"/content-categories/{category.id}/bulk",
+            data={"bulk_text": "宏观政策"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        session = SessionLocal()
+        remaining = session.query(WatchContent).filter_by(category_id=category.id).all()
+        session.close()
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].text, "宏观政策")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add content categories for watch contents with filtering, creation, deletion, and grouped selection in the UI
- implement bulk editing textarea for category contents and surface category context in tasks and results views
- cover the new workflow with an integration-style test exercising the bulk editor

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcda71fbf083208145a2113ebb076d