### PR TITLE
Add step-level crawl logging to task monitoring view

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from flask import Flask, flash, redirect, render_template, request, url_for
+from sqlalchemy.orm import joinedload
 
 from crawler import SIMILARITY_THRESHOLD
 from database import SessionLocal, init_db
@@ -207,7 +208,13 @@ def view_task(task_id: int) -> Any:
     if not task:
         flash("未找到任务", "danger")
         return redirect(url_for("list_tasks"))
-    logs = session.query(CrawlLog).filter(CrawlLog.task_id == task_id).order_by(CrawlLog.run_started_at.desc()).all()
+    logs = (
+        session.query(CrawlLog)
+        .options(joinedload(CrawlLog.entries))
+        .filter(CrawlLog.task_id == task_id)
+        .order_by(CrawlLog.run_started_at.desc())
+        .all()
+    )
     results = (
         session.query(CrawlResult)
         .filter(CrawlResult.task_id == task_id)

--- a/crawler.py
+++ b/crawler.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Iterable, List
+from typing import Iterable, List, Tuple
 from urllib.parse import urljoin
 
 import requests
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 
 from database import SessionLocal
 from email_utils import send_email
-from models import CrawlLog, CrawlResult, MonitorTask, WatchContent
+from models import CrawlLog, CrawlLogDetail, CrawlResult, MonitorTask, WatchContent
 from nlp import similarity
 
 SIMILARITY_THRESHOLD = 0.6
@@ -87,37 +87,54 @@ def notify(task: MonitorTask, title: str, url: str, summary: str, matches: list[
 
 def run_task(task_id: int) -> None:
     session = SessionLocal()
+    log_details: list[Tuple[str, str]] = []
+    log_entry_id: int | None = None
     try:
         task = session.get(MonitorTask, task_id)
         if not task:
             LOGGER.error("Task %s not found", task_id)
             return
+
         log_entry = CrawlLog(task=task)
         session.add(log_entry)
         session.commit()
+        log_entry_id = log_entry.id
+
+        def add_detail(message: str, level: str = "info") -> None:
+            log_details.append((message, level))
+
+        add_detail(f"开始执行任务《{task.name}》", "info")
 
         website = task.website
         if not website:
             raise CrawlError("监控任务未配置网站")
 
+        add_detail(f"准备抓取网站：{website.url}")
         LOGGER.info("Running task %s on %s", task.name, website.url)
         new_html = fetch_html(website.url)
-        matched_results = []
+        add_detail("主页面抓取成功")
+        matched_results: list[tuple[str, str, str, list[tuple[WatchContent, float]]]] = []
 
         if website.fetch_subpages:
             new_links = compare_links(website.last_snapshot, new_html, website.url)
             LOGGER.debug("Found %d new links", len(new_links))
+            add_detail(f"发现新链接 {len(new_links)} 个")
 
             for link in new_links:
+                add_detail(f"抓取子链接：{link}")
                 try:
                     link_html = fetch_html(link)
+                    add_detail(f"子链接抓取成功：{link}")
                 except Exception:  # noqa: BLE001
                     LOGGER.exception("Failed to fetch sub link %s", link)
+                    add_detail(f"子链接抓取失败：{link}", "warning")
                     continue
                 title, summary = summarize_html(link_html)
                 scores = score_contents(summary, task.watch_contents)
                 matches = [(content, score) for content, score in scores if score >= SIMILARITY_THRESHOLD]
                 if matches:
+                    matched_contents = ", ".join(f"{content.text}({score:.2f})" for content, score in matches)
+                    add_detail(f"子链接命中关注项：{matched_contents}", "success")
                     best_match = max(matches, key=lambda item: item[1])
                     result = CrawlResult(
                         task=task,
@@ -132,11 +149,14 @@ def run_task(task_id: int) -> None:
                     matched_results.append((title, link, summary, matches))
         else:
             has_changed = website.last_snapshot != new_html
+            add_detail("检测到页面发生变化" if has_changed else "页面内容无变化")
             if has_changed:
                 title, summary = summarize_html(new_html)
                 scores = score_contents(summary, task.watch_contents)
                 matches = [(content, score) for content, score in scores if score >= SIMILARITY_THRESHOLD]
                 if matches:
+                    matched_contents = ", ".join(f"{content.text}({score:.2f})" for content, score in matches)
+                    add_detail(f"主页面命中关注项：{matched_contents}", "success")
                     best_match = max(matches, key=lambda item: item[1])
                     result = CrawlResult(
                         task=task,
@@ -150,6 +170,11 @@ def run_task(task_id: int) -> None:
                     session.add(result)
                     matched_results.append((title, website.url, summary, matches))
 
+        if matched_results:
+            add_detail(f"发现匹配结果 {len(matched_results)} 条", "success")
+        else:
+            add_detail("未发现符合条件的内容")
+
         website.last_snapshot = new_html
         website.last_fetched_at = datetime.utcnow()
         task.last_run_at = datetime.utcnow()
@@ -157,6 +182,19 @@ def run_task(task_id: int) -> None:
 
         session.add(website)
         session.add(task)
+
+        if log_entry_id is None:
+            session.flush()
+            log_entry_id = log_entry.id
+
+        log_entry = session.get(CrawlLog, log_entry_id)
+        if log_entry is None:
+            raise CrawlError("日志记录不存在")
+
+        for message, level in log_details:
+            detail = CrawlLogDetail(log_id=log_entry.id, message=message, level=level)
+            session.add(detail)
+
         log_entry.status = task.last_status
         log_entry.run_finished_at = datetime.utcnow()
         log_entry.message = f"发现匹配结果 {len(matched_results)} 条"
@@ -168,12 +206,35 @@ def run_task(task_id: int) -> None:
     except Exception as exc:  # noqa: BLE001
         session.rollback()
         LOGGER.exception("Task %s failed", task_id)
+        log_details.append(("任务执行失败，已回滚未完成操作", "error"))
+        log_details.append((f"错误信息：{exc}", "error"))
+
         task = session.get(MonitorTask, task_id)
         if task:
             task.last_status = "failed"
             task.last_run_at = datetime.utcnow()
             session.add(task)
-        log_entry = CrawlLog(task_id=task_id, status="failed", message=str(exc), run_finished_at=datetime.utcnow())
+
+        if log_entry_id is None:
+            log_entry = CrawlLog(task_id=task_id)
+            session.add(log_entry)
+            session.flush()
+            log_entry_id = log_entry.id
+
+        log_entry = session.get(CrawlLog, log_entry_id)
+        if log_entry is None:
+            log_entry = CrawlLog(task_id=task_id)
+            session.add(log_entry)
+            session.flush()
+            log_entry_id = log_entry.id
+
+        for message, level in log_details:
+            detail = CrawlLogDetail(log_id=log_entry.id, message=message, level=level)
+            session.add(detail)
+
+        log_entry.status = "failed"
+        log_entry.run_finished_at = datetime.utcnow()
+        log_entry.message = str(exc)
         session.add(log_entry)
         session.commit()
     finally:

--- a/models.py
+++ b/models.py
@@ -99,6 +99,12 @@ class CrawlLog(Base):
     message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     task: Mapped[MonitorTask] = relationship("MonitorTask", back_populates="logs")
+    entries: Mapped[List["CrawlLogDetail"]] = relationship(
+        "CrawlLogDetail",
+        back_populates="log",
+        cascade="all, delete-orphan",
+        order_by="CrawlLogDetail.created_at",
+    )
 
 
 class CrawlResult(Base):
@@ -117,3 +123,15 @@ class CrawlResult(Base):
     task: Mapped[MonitorTask] = relationship("MonitorTask", back_populates="results")
     website: Mapped[Website] = relationship("Website")
     content: Mapped[WatchContent | None] = relationship("WatchContent")
+
+
+class CrawlLogDetail(Base):
+    __tablename__ = "crawl_log_details"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    log_id: Mapped[int] = mapped_column(ForeignKey("crawl_logs.id"), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    level: Mapped[str] = mapped_column(String(20), default="info")
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+
+    log: Mapped[CrawlLog] = relationship("CrawlLog", back_populates="entries")

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -29,6 +29,21 @@
       <td>{{ log.status }}</td>
       <td>{{ log.message }}</td>
     </tr>
+    {% if log.entries %}
+    <tr>
+      <td colspan="4">
+        <ul class="list-unstyled mb-0">
+          {% for entry in log.entries %}
+          <li class="mb-1">
+            <span class="badge text-bg-secondary me-1">{{ entry.level|upper }}</span>
+            <small class="text-muted me-2">{{ entry.created_at }}</small>
+            {{ entry.message }}
+          </li>
+          {% endfor %}
+        </ul>
+      </td>
+    </tr>
+    {% endif %}
     {% else %}
     <tr>
       <td colspan="4" class="text-center text-muted">暂无日志</td>


### PR DESCRIPTION
## Summary
- add a CrawlLogDetail model to persist step-level log entries for monitor tasks
- update the crawler to capture detailed run steps and failure information in crawl logs
- enhance the task detail page to render the recorded log entries with eager loading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcdade373c8320837a3a036ae6770e