### PR TITLE
Fix task form rendering without form_data context

### DIFF
--- a/app.py
+++ b/app.py
@@ -398,12 +398,20 @@ def create_task() -> Any:
         .all()
     )
     has_contents = any(category.contents for category in categories)
+    form_data = {
+        "name": "",
+        "website_id": None,
+        "notification_method": "email",
+        "notification_email": "",
+    }
+    selected_content_ids: set[int] = set()
+
     if request.method == "POST":
         name = request.form.get("name", "").strip()
         website_id = int(request.form.get("website_id", "0") or 0)
         notification_method = request.form.get("notification_method", "email").strip() or "email"
         notification_email_raw = request.form.get("notification_email", "").strip()
-        selected_content_ids = [int(content_id) for content_id in request.form.getlist("content_ids")]
+        selected_content_ids = {int(content_id) for content_id in request.form.getlist("content_ids")}
 
         recipients = [email.strip() for email in notification_email_raw.replace(";", ",").split(",") if email.strip()]
         form_data = {
@@ -439,6 +447,8 @@ def create_task() -> Any:
         websites=websites,
         categories=categories,
         has_contents=has_contents,
+        form_data=form_data,
+        selected_content_ids=selected_content_ids,
     )
 
 

--- a/templates/tasks/form.html
+++ b/templates/tasks/form.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 {% set is_edit = task is not none %}
+{% set selected_ids = selected_content_ids or [] %}
 <h2>{{ '编辑监控任务' if is_edit else '新增监控任务' }}</h2>
 <form method="post" class="mt-3">
   <div class="mb-3">
@@ -45,7 +46,7 @@
           {% for content in category.contents %}
           <div class="col-md-6 col-lg-4">
             <div class="form-check">
-              <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids">
+              <input class="form-check-input" type="checkbox" value="{{ content.id }}" id="content{{ content.id }}" name="content_ids" {% if content.id in selected_ids %}checked{% endif %}>
               <label class="form-check-label" for="content{{ content.id }}">{{ content.text }}</label>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- initialize default form values when rendering the task creation form
- keep previously selected content checkboxes when validation fails

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dce47f7b148320aac8ad1e96cdc762