### PR TITLE
Improve timezone awareness and task list display

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -25,6 +25,10 @@ class CrawlError(RuntimeError):
 def fetch_html(url: str) -> str:
     response = requests.get(url, timeout=20)
     response.raise_for_status()
+    if not response.encoding or response.encoding.lower() == "iso-8859-1":
+        apparent = response.apparent_encoding
+        if apparent:
+            response.encoding = apparent
     return response.text
 
 

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,53 @@
+"""Logging helpers with timezone aware timestamps."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from time_utils import get_local_timezone
+
+
+class TimezoneFormatter(logging.Formatter):
+    """Formatter that renders timestamps with explicit timezone information."""
+
+    def __init__(
+        self,
+        fmt: str | None = None,
+        datefmt: str | None = None,
+        style: str = "%",
+        tzinfo=None,
+    ) -> None:
+        super().__init__(fmt=fmt, datefmt=datefmt, style=style)
+        self._tzinfo = tzinfo or get_local_timezone()
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:  # noqa: N802
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc).astimezone(self._tzinfo)
+        if datefmt:
+            return dt.strftime(datefmt)
+        return dt.isoformat(timespec="seconds")
+
+
+_configured = False
+
+
+def configure_logging(level: int = logging.INFO, fmt: Optional[str] = None) -> None:
+    """Configure the root logger to include timezone aware timestamps."""
+    global _configured
+    if _configured:
+        return
+
+    formatter = TimezoneFormatter(
+        fmt or "%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S %Z%z",
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+    _configured = True

--- a/templates/tasks/list.html
+++ b/templates/tasks/list.html
@@ -10,15 +10,17 @@
       <th>名称</th>
       <th>网站</th>
       <th>关注内容</th>
-      <th>通知方式</th>
-      <th>通知配置</th>
       <th>最后执行</th>
-      <th>状态</th>
+      <th>下一次执行</th>
+      <th>任务状态</th>
+      <th>执行状态</th>
+      <th>上次结果</th>
       <th>操作</th>
     </tr>
   </thead>
   <tbody>
-    {% for task in tasks %}
+    {% for row in task_rows %}
+    {% set task = row.task %}
     <tr>
       <td><a href="{{ url_for('view_task', task_id=task.id) }}">{{ task.name }}</a></td>
       <td>{{ task.website.name if task.website else '未配置' }}</td>
@@ -27,16 +29,11 @@
           <span class="badge text-bg-secondary">{{ content.category.name if content.category else '未分类' }}：{{ content.text }}</span>
         {% endfor %}
       </td>
-      <td>{% if task.notification_method == 'dingtalk' %}钉钉{% else %}邮件{% endif %}</td>
-      <td>
-        {% if task.notification_method == 'dingtalk' %}
-          钉钉群机器人
-        {% else %}
-          {{ task.notification_email or '未配置' }}
-        {% endif %}
-      </td>
-      <td>{{ task.last_run_at or '尚未执行' }}</td>
-      <td>{{ '运行中' if task.is_active else '已暂停' }} / {{ task.last_status or '未执行' }}</td>
+      <td>{{ row.last_run_at|format_datetime or '尚未执行' }}</td>
+      <td>{{ row.next_run_at|format_datetime or '待调度' }}</td>
+      <td>{{ '有效' if task.is_active else '无效' }}</td>
+      <td>{{ '执行中' if row.is_running else '未执行' }}</td>
+      <td>{{ row.last_result_label }}</td>
       <td>
         <a class="btn btn-sm btn-info" href="{{ url_for('edit_task', task_id=task.id) }}">编辑</a>
         <form action="{{ url_for('toggle_task', task_id=task.id) }}" method="post" class="d-inline">
@@ -50,7 +47,7 @@
     {% endfor %}
   </tbody>
 </table>
-{% if not tasks %}
+{% if not task_rows %}
 <p class="text-muted">当前暂无监控任务，请先创建。</p>
 {% endif %}
 {% endblock %}

--- a/time_utils.py
+++ b/time_utils.py
@@ -1,0 +1,50 @@
+"""Utility helpers for timezone-aware date handling."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+try:
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - zoneinfo always available on Py3.9+
+    ZoneInfo = None  # type: ignore
+
+_DEFAULT_TZ_OFFSET = timezone(timedelta(hours=8))
+
+
+def get_local_timezone():
+    """Return the system configured timezone or fall back to UTC+8."""
+    local_dt = datetime.now().astimezone()
+    tzinfo = local_dt.tzinfo
+    if tzinfo is not None:
+        offset = local_dt.utcoffset()
+        if offset and offset != timedelta(0):
+            return tzinfo
+    if ZoneInfo is not None:
+        try:
+            return ZoneInfo("Asia/Shanghai")
+        except Exception:  # pragma: no cover - fallback handled below
+            pass
+    return _DEFAULT_TZ_OFFSET
+
+
+def ensure_utc(dt: datetime) -> datetime:
+    """Attach UTC timezone information to naive datetimes."""
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc)
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def to_local(dt: Optional[datetime]) -> Optional[datetime]:
+    """Convert a datetime to the local timezone."""
+    if dt is None:
+        return None
+    return ensure_utc(dt).astimezone(get_local_timezone())
+
+
+def format_local_datetime(dt: Optional[datetime], fmt: str = "%Y-%m-%d %H:%M:%S %Z%z") -> str:
+    """Format a datetime into a string that includes timezone information."""
+    local_dt = to_local(dt)
+    if local_dt is None:
+        return ""
+    return local_dt.strftime(fmt)


### PR DESCRIPTION
## Summary
- configure application logging to emit timezone-aware timestamps using the system setting with a fallback to UTC+8
- ensure crawled pages honour their declared or detected encoding so Chinese content renders correctly
- enrich the task list view with next-run timing and clearer status columns while hiding notification details

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcee3fe1208320b3f82807027f6fb8