### PR TITLE
feat: enhance monitoring logs and snapshot viewer

### DIFF
--- a/templates/results/list.html
+++ b/templates/results/list.html
@@ -1,6 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>监控结果</h2>
+{% set status_styles = {
+  'running': ('warning', '执行中'),
+  'success': ('success', '成功'),
+  'completed': ('primary', '已完成'),
+  'failed': ('danger', '失败')
+} %}
+<h2>监控记录</h2>
 <form class="row g-3 mb-4" method="get">
   <div class="col-md-3">
     <label class="form-label">任务</label>
@@ -21,17 +27,11 @@
     </select>
   </div>
   <div class="col-md-3">
-    <label class="form-label">关注内容</label>
-    <select class="form-select" name="content_id">
+    <label class="form-label">状态</label>
+    <select class="form-select" name="status">
       <option value="">全部</option>
-      {% for category in categories %}
-        {% if category.contents %}
-        <optgroup label="{{ category.name }}">
-          {% for content in category.contents %}
-          <option value="{{ content.id }}" {% if query_args.content_id == content.id|string %}selected{% endif %}>{{ content.text }}</option>
-          {% endfor %}
-        </optgroup>
-        {% endif %}
+      {% for key, label in status_choices.items() %}
+      <option value="{{ key }}" {% if query_args.status == key %}selected{% endif %}>{{ label }}</option>
       {% endfor %}
     </select>
   </div>
@@ -47,43 +47,48 @@
     <button class="btn btn-primary" type="submit">筛选</button>
   </div>
 </form>
-<table class="table table-striped">
-  <thead>
-    <tr>
-      <th>时间</th>
-      <th>任务</th>
-      <th>网站</th>
-      <th>关注内容</th>
-      <th>标题</th>
-      <th>链接</th>
-      <th>相似度</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for result in results %}
-    <tr>
-      <td>{{ result.created_at }}</td>
-      <td>{{ result.task.name }}</td>
-      <td>{{ result.website.name }}</td>
-      <td>
-        {% if result.content %}
-          <div>{{ result.content.text }}</div>
-          <small class="text-muted">分类：{{ result.content.category.name if result.content.category else '未分类' }}</small>
-        {% else %}
-          未知
+{% if logs %}
+  {% for log in logs %}
+  {% set status = status_styles.get(log.status, ('secondary', log.status or '未知')) %}
+  <div class="card mb-3">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <div>
+        <span class="badge text-bg-{{ status[0] }}">{{ status[1] }}</span>
+        <span class="ms-2">任务：<strong>{{ log.task.name }}</strong></span>
+        {% if log.task.website %}
+        <span class="ms-2">网站：<a href="{{ log.task.website.url }}" target="_blank">{{ log.task.website.name }}</a></span>
         {% endif %}
-      </td>
-      <td>{{ result.link_title or '无标题' }}</td>
-      <td><a href="{{ result.discovered_url }}" target="_blank">打开</a></td>
-      <td>{{ '%.2f'|format(result.similarity_score or 0) }}</td>
-    </tr>
-    {% else %}
-    <tr>
-      <td colspan="7" class="text-center text-muted">暂无记录</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+      </div>
+      <div class="small text-muted">日志编号：{{ log.id }}</div>
+    </div>
+    <div class="card-body">
+      <p class="mb-1"><strong>开始时间：</strong> {{ log.run_started_at|format_datetime if log.run_started_at else '未知' }}</p>
+      <p class="mb-1"><strong>结束时间：</strong> {{ log.run_finished_at|format_datetime if log.run_finished_at else '未结束' }}</p>
+      <p class="text-muted">{{ log.message or '暂无汇总信息' }}</p>
+      <h6 class="mt-3">日志明细</h6>
+      <ul class="list-unstyled mb-3">
+        {% for entry in log.entries[:5] %}
+        <li class="mb-2">
+          <span class="badge text-bg-secondary me-2">{{ entry.level|upper }}</span>
+          <small class="text-muted me-2">{{ entry.created_at|format_datetime if entry.created_at else '' }}</small>
+          {{ entry.message }}
+        </li>
+        {% else %}
+        <li class="text-muted">暂无日志明细</li>
+        {% endfor %}
+      </ul>
+      {% set remaining = log.entries|length - 5 %}
+      {% if remaining > 0 %}
+      <p class="small text-muted">还有 {{ remaining }} 条记录，可在任务详情中查看。</p>
+      {% endif %}
+      <a class="btn btn-sm btn-outline-primary" href="{{ url_for('view_task', task_id=log.task_id) }}#log-{{ log.id }}">查看完整日志</a>
+    </div>
+  </div>
+  {% endfor %}
+{% else %}
+<div class="alert alert-secondary">暂无监控记录。</div>
+{% endif %}
+{% if total_pages > 1 %}
 <nav>
   <ul class="pagination">
     {% for p in range(1, total_pages + 1) %}
@@ -93,4 +98,5 @@
     {% endfor %}
   </ul>
 </nav>
+{% endif %}
 {% endblock %}

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -30,6 +30,9 @@
             未配置
           {% endif %}
         </p>
+        {% if task.website and task.website.last_snapshot %}
+        <p class="mb-1"><a href="{{ url_for('view_website_snapshot', website_id=task.website.id) }}" class="link-primary">查看最近抓取快照</a></p>
+        {% endif %}
         <p class="mb-1"><strong>关注内容：</strong>
           {% if task.watch_contents %}
             {% for content in task.watch_contents %}

--- a/templates/websites/list.html
+++ b/templates/websites/list.html
@@ -23,8 +23,11 @@
       <td>{{ '是' if website.fetch_subpages else '否' }}</td>
       <td>{{ website.interval_minutes }}</td>
       <td>{{ website.last_fetched_at or '尚未抓取' }}</td>
-      <td>
+      <td class="d-flex flex-wrap gap-2">
         <a href="{{ url_for('edit_website', website_id=website.id) }}" class="btn btn-sm btn-secondary">编辑</a>
+        {% if website.last_snapshot %}
+        <a href="{{ url_for('view_website_snapshot', website_id=website.id) }}" class="btn btn-sm btn-outline-primary">查看快照</a>
+        {% endif %}
         <form action="{{ url_for('delete_website', website_id=website.id) }}" method="post" class="d-inline" onsubmit="return confirm('确认删除该网站？');">
           <button class="btn btn-sm btn-danger">删除</button>
         </form>

--- a/templates/websites/snapshot.html
+++ b/templates/websites/snapshot.html
@@ -1,0 +1,72 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+  <h2 class="mb-0">网站快照 - {{ website.name }}</h2>
+  <div class="d-flex flex-wrap gap-2">
+    <a class="btn btn-secondary" href="{{ url_for('list_websites') }}">返回网站列表</a>
+    {% if related_tasks %}
+      {% for task in related_tasks %}
+      <a class="btn btn-outline-primary" href="{{ url_for('view_task', task_id=task.id) }}">{{ task.name }}</a>
+      {% endfor %}
+    {% endif %}
+  </div>
+</div>
+<p class="text-muted">最近抓取时间：{{ website.last_fetched_at or '尚未抓取' }}</p>
+{% if snapshot_lines %}
+<div class="card mb-4">
+  <div class="card-header">逐条浏览快照内容</div>
+  <div class="card-body">
+    <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+      <button type="button" class="btn btn-outline-secondary" id="snapshot-prev" aria-label="上一条">上一条</button>
+      <button type="button" class="btn btn-outline-secondary" id="snapshot-next" aria-label="下一条">下一条</button>
+      <div class="ms-auto small text-muted">第 <span id="snapshot-index">1</span> / {{ snapshot_lines|length }} 行</div>
+    </div>
+    <pre id="snapshot-current" class="border rounded p-3 bg-light" style="white-space: pre-wrap; min-height: 6rem;">{{ snapshot_lines[0] }}</pre>
+  </div>
+</div>
+<div class="card">
+  <div class="card-header">完整快照内容</div>
+  <div class="card-body">
+    <pre class="border rounded p-3 bg-light" style="white-space: pre-wrap; max-height: 60vh; overflow:auto;">{{ snapshot_lines|join('\n') }}</pre>
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const lines = {{ snapshot_lines|tojson }};
+    const prevBtn = document.getElementById('snapshot-prev');
+    const nextBtn = document.getElementById('snapshot-next');
+    const currentEl = document.getElementById('snapshot-current');
+    const indexEl = document.getElementById('snapshot-index');
+    let index = 0;
+
+    function updateView() {
+      if (!lines.length) {
+        return;
+      }
+      currentEl.textContent = lines[index] || '';
+      indexEl.textContent = index + 1;
+      prevBtn.disabled = index <= 0;
+      nextBtn.disabled = index >= lines.length - 1;
+    }
+
+    prevBtn.addEventListener('click', function () {
+      if (index > 0) {
+        index -= 1;
+        updateView();
+      }
+    });
+
+    nextBtn.addEventListener('click', function () {
+      if (index < lines.length - 1) {
+        index += 1;
+        updateView();
+      }
+    });
+
+    updateView();
+  });
+</script>
+{% else %}
+<div class="alert alert-secondary">暂时没有可供展示的快照内容。</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- log captured page titles for main and subpage fetches to improve monitoring transparency
- add a snapshot viewer page with navigation and surface quick links from tasks and website listings
- replace the monitoring records view with aggregated crawl logs and filters so every run is visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf2024cf08320baee41ff5f1515f8