### PR TITLE
Align DingTalk webhook payload with expected format

### DIFF
--- a/email_utils.py
+++ b/email_utils.py
@@ -120,14 +120,12 @@ def send_email(
         server.sendmail(settings.sender, recipients, message.as_string())
 
 
-def send_dingtalk_message(title: str, markdown: str) -> None:
+def send_dingtalk_message(title: str, content: str, url: str | None = None) -> None:
     webhook_url = _get_dingtalk_webhook()
     payload = {
-        "msgtype": "markdown",
-        "markdown": {
-            "title": title,
-            "text": markdown,
-        },
+        "title": title,
+        "content": content,
+        "url": url or "",
     }
     response = requests.post(webhook_url, json=payload, timeout=10)
     response.raise_for_status()


### PR DESCRIPTION
## Summary
- Update the DingTalk notification helper to send the required JSON body containing title, content, and url fields.
- Adjust the crawler notification flow to assemble the plain-text content for DingTalk and include the target article link.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf44fb6108320ac89612508b7a2d0