### PR TITLE
Use headless browser rendering and surface snapshot titles

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,10 +78,31 @@ def view_website_snapshot(website_id: int) -> Any:
             flash("未找到网站", "danger")
             return redirect(url_for("list_websites"))
 
-        main_snapshot, subpage_snapshots = parse_snapshot(website.last_snapshot)
-        snapshot_entries: list[dict[str, str]] = subpage_snapshots
-        if not snapshot_entries and main_snapshot:
-            snapshot_entries = [{"url": website.url, "html": main_snapshot}]
+        main_snapshot, subpage_snapshots, main_title = parse_snapshot(website.last_snapshot)
+        snapshot_entries: list[dict[str, str | None]] = []
+        if main_snapshot:
+            snapshot_entries.append(
+                {
+                    "url": website.url,
+                    "html": main_snapshot,
+                    "title": main_title,
+                    "label": "主页面",
+                }
+            )
+
+        for index, entry in enumerate(subpage_snapshots, start=1):
+            if not entry.get("url") or not entry.get("html"):
+                continue
+            snapshot_entries.append(
+                {
+                    "url": entry.get("url"),
+                    "html": entry.get("html"),
+                    "title": entry.get("title"),
+                    "label": f"子链接 {index}",
+                }
+            )
+
+        snapshot_entries = [item for item in snapshot_entries if item.get("url") and item.get("html")]
 
         related_tasks = [
             {"id": task.id, "name": task.name}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask>=3.1.0
 SQLAlchemy>=2.0.23
 requests>=2.31.0
 beautifulsoup4>=4.12.2
+playwright>=1.42.0
 
 # 以下依赖仅在使用语义相似度模型时需要，Python 3.13 环境可选择跳过
 sentence-transformers>=2.2.2; python_version < "3.13"

--- a/templates/websites/snapshot.html
+++ b/templates/websites/snapshot.html
@@ -20,7 +20,7 @@
   <div class="accordion-item">
     <h2 class="accordion-header" id="{{ heading_id }}">
       <button class="accordion-button{% if not loop.first %} collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ collapse_id }}" aria-expanded="{{ 'true' if loop.first else 'false' }}" aria-controls="{{ collapse_id }}">
-        子链接 {{ loop.index }}：{{ entry.url }}
+        {{ entry.label or ('子链接 ' ~ loop.index) }}：{{ entry.url }}{% if entry.title %}（{{ entry.title }}）{% endif %}
       </button>
     </h2>
     <div id="{{ collapse_id }}" class="accordion-collapse collapse{% if loop.first %} show{% endif %}" aria-labelledby="{{ heading_id }}" data-bs-parent="#snapshot-accordion">

--- a/tests/test_snapshot_utils.py
+++ b/tests/test_snapshot_utils.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+from crawler import build_snapshot, parse_snapshot, summarize_html
+
+
+def test_summarize_html_prefers_heading_over_title() -> None:
+    html = """
+    <html>
+      <head><title>HTML Title</title></head>
+      <body>
+        <h1>Rendered Heading</h1>
+        <p>第一段内容。</p>
+      </body>
+    </html>
+    """
+    title, summary = summarize_html(html)
+    assert title == "Rendered Heading"
+    assert "第一段内容" in summary
+
+
+def test_build_and_parse_snapshot_preserve_titles() -> None:
+    main_html = "<html><body><h1>主标题</h1><p>内容A</p></body></html>"
+    sub_html = "<html><body><h1>子标题</h1><p>内容B</p></body></html>"
+
+    snapshot = build_snapshot(
+        main_html,
+        [
+            {
+                "url": "https://example.com/sub",
+                "html": sub_html,
+                "title": "子标题",
+            }
+        ],
+        main_title="主标题",
+    )
+
+    parsed_main_html, entries, main_title = parse_snapshot(snapshot)
+
+    assert parsed_main_html == main_html
+    assert main_title == "主标题"
+    assert entries[0]["url"] == "https://example.com/sub"
+    assert entries[0]["title"] == "子标题"
+
+
+def test_parse_snapshot_legacy_payloads_fill_missing_titles() -> None:
+    main_html = "<html><body><h1>旧标题</h1><p>旧内容</p></body></html>"
+    sub_html = "<html><body><h2>旧子标题</h2><p>子内容</p></body></html>"
+
+    legacy_payload = json.dumps(
+        {
+            "main_html": main_html,
+            "subpages": [
+                {
+                    "url": "https://legacy.example.com/sub",
+                    "html": sub_html,
+                }
+            ],
+        }
+    )
+
+    parsed_main_html, entries, main_title = parse_snapshot(legacy_payload)
+
+    assert parsed_main_html == main_html
+    assert main_title == "旧标题"
+    assert entries[0]["title"] == "旧子标题"


### PR DESCRIPTION
## Summary
- render monitored pages with a headless browser before parsing so the detected title reflects on-page headings
- persist detected titles in stored snapshots and show them alongside URLs in the snapshot accordion
- cover the new parsing logic with snapshot unit tests and declare the Playwright dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcfa49adf88320a7109175f898141d