### PR TITLE
Normalize snapshots and derive titles from content

### DIFF
--- a/app.py
+++ b/app.py
@@ -78,7 +78,7 @@ def view_website_snapshot(website_id: int) -> Any:
             flash("未找到网站", "danger")
             return redirect(url_for("list_websites"))
 
-        main_snapshot, subpage_snapshots, main_title = parse_snapshot(website.last_snapshot)
+        main_snapshot, subpage_snapshots, main_title, main_text = parse_snapshot(website.last_snapshot)
         snapshot_entries: list[dict[str, str | None]] = []
         if main_snapshot:
             snapshot_entries.append(
@@ -86,6 +86,7 @@ def view_website_snapshot(website_id: int) -> Any:
                     "url": website.url,
                     "html": main_snapshot,
                     "title": main_title,
+                    "text": main_text,
                     "label": "主页面",
                 }
             )
@@ -98,6 +99,7 @@ def view_website_snapshot(website_id: int) -> Any:
                     "url": entry.get("url"),
                     "html": entry.get("html"),
                     "title": entry.get("title"),
+                    "text": entry.get("text"),
                     "label": f"子链接 {index}",
                 }
             )


### PR DESCRIPTION
## Summary
- normalize stored snapshots by saving flattened body text alongside HTML for main and sub pages
- generate link titles using NLP-based main idea extraction from snapshot text and expose the text in snapshot views
- adjust change detection to rely on text comparisons and extend tests for new snapshot structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dcfe03d6888320b256b663877065d0