### PR TITLE
feat: paginate task logs and send feed card notifications

### DIFF
--- a/email_utils.py
+++ b/email_utils.py
@@ -5,7 +5,7 @@ import smtplib
 from dataclasses import dataclass
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Iterable
+from typing import Any, Iterable
 
 import requests
 from flask import current_app
@@ -120,12 +120,7 @@ def send_email(
         server.sendmail(settings.sender, recipients, message.as_string())
 
 
-def send_dingtalk_message(title: str, content: str, url: str | None = None) -> None:
+def send_dingtalk_message(payload: dict[str, Any]) -> None:
     webhook_url = _get_dingtalk_webhook()
-    payload = {
-        "title": title,
-        "content": content,
-        "url": url or "",
-    }
     response = requests.post(webhook_url, json=payload, timeout=10)
     response.raise_for_status()

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -72,33 +72,56 @@
 
 <h3 class="h5">执行日志</h3>
 {% if logs %}
-  {% for log in logs %}
-    {% set status = status_styles.get(log.status, ('secondary', log.status or '未知')) %}
-    <div class="card mb-3" id="log-{{ log.id }}" data-log-id="{{ log.id }}" {% if active_log and log.id == active_log.id %}data-log-running="true" data-fetch-url="{{ url_for('stream_task_log_entries', task_id=task.id, log_id=log.id) }}"{% endif %}>
-      <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
-        <div>
-          <span class="badge text-bg-{{ status[0] }}" data-log-status>{{ status[1] }}</span>
-          <span class="ms-2">开始：{{ log.run_started_at or '未知' }}</span>
-          <span class="ms-2">结束：<span data-log-finished>{{ log.run_finished_at or (log.status == 'running' and '进行中' or '未知') }}</span></span>
+  <div class="accordion" id="logAccordion">
+    {% for log in logs %}
+      {% set status = status_styles.get(log.status, ('secondary', log.status or '未知')) %}
+      {% set is_running = active_log and log.id == active_log.id %}
+      <div class="accordion-item" id="log-{{ log.id }}" data-log-id="{{ log.id }}" {% if is_running %}data-log-running="true" data-fetch-url="{{ url_for('stream_task_log_entries', task_id=task.id, log_id=log.id) }}"{% endif %}>
+        <h2 class="accordion-header" id="heading-{{ log.id }}">
+          <button class="accordion-button {% if not is_running %}collapsed{% endif %} py-2" type="button" data-bs-toggle="collapse" data-bs-target="#log-body-{{ log.id }}" aria-expanded="{{ 'true' if is_running else 'false' }}" aria-controls="log-body-{{ log.id }}">
+            <div class="d-flex flex-grow-1 flex-wrap align-items-center gap-2">
+              <span class="badge text-bg-{{ status[0] }}" data-log-status>{{ status[1] }}</span>
+              <span class="text-muted small">编号：{{ log.id }}</span>
+              <span class="text-muted small">开始：{{ log.run_started_at or '未知' }}</span>
+              <span class="text-muted small">结束：<span data-log-finished>{{ log.run_finished_at or (log.status == 'running' and '进行中' or '未知') }}</span></span>
+              <span class="text-muted small text-truncate">{{ log.message or '暂无汇总信息' }}</span>
+            </div>
+          </button>
+        </h2>
+        <div id="log-body-{{ log.id }}" class="accordion-collapse collapse {% if is_running %}show{% endif %}" aria-labelledby="heading-{{ log.id }}" data-bs-parent="#logAccordion">
+          <div class="accordion-body">
+            <p class="text-muted mb-3" data-log-message>{{ log.message or '暂无汇总信息' }}</p>
+            <ul class="list-unstyled mb-0 log-entry-list">
+              {% for entry in log.entries %}
+              <li class="mb-2" data-entry-id="{{ entry.id }}">
+                <span class="badge text-bg-secondary me-2">{{ entry.level|upper }}</span>
+                <small class="text-muted me-2">{{ entry.created_at }}</small>
+                {{ entry.message }}
+              </li>
+              {% else %}
+              <li class="text-muted" data-empty-log>暂无日志明细</li>
+              {% endfor %}
+            </ul>
+          </div>
         </div>
-        <div class="text-muted small">日志编号：{{ log.id }}</div>
       </div>
-      <div class="card-body">
-        <p class="text-muted mb-3" data-log-message>{{ log.message or '暂无汇总信息' }}</p>
-        <ul class="list-unstyled mb-0 log-entry-list">
-          {% for entry in log.entries %}
-          <li class="mb-2" data-entry-id="{{ entry.id }}">
-            <span class="badge text-bg-secondary me-2">{{ entry.level|upper }}</span>
-            <small class="text-muted me-2">{{ entry.created_at }}</small>
-            {{ entry.message }}
-          </li>
-          {% else %}
-          <li class="text-muted" data-empty-log>暂无日志明细</li>
-          {% endfor %}
-        </ul>
-      </div>
-    </div>
-  {% endfor %}
+    {% endfor %}
+  </div>
+  {% if total_pages > 1 %}
+  <nav aria-label="日志分页" class="mt-3">
+    <ul class="pagination justify-content-center">
+      <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('view_task', task_id=task.id, page=page-1) }}" tabindex="-1">上一页</a>
+      </li>
+      {% for p in range(1, total_pages + 1) %}
+      <li class="page-item {% if p == page %}active{% endif %}"><a class="page-link" href="{{ url_for('view_task', task_id=task.id, page=p) }}">{{ p }}</a></li>
+      {% endfor %}
+      <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
+        <a class="page-link" href="{{ url_for('view_task', task_id=task.id, page=page+1) }}">下一页</a>
+      </li>
+    </ul>
+  </nav>
+  {% endif %}
 {% else %}
   <div class="alert alert-secondary">暂无执行日志。</div>
 {% endif %}


### PR DESCRIPTION
## Summary
- collapse task detail execution logs into an accordion with pagination
- paginate task crawl logs server-side to support the new accordion view
- aggregate matched results into a single feed card style notification for email and DingTalk

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd24ef15a483208d27c940d9a18bf8