### PR TITLE
Add notification send logging and timezone display improvements

### DIFF
--- a/email_utils.py
+++ b/email_utils.py
@@ -120,7 +120,8 @@ def send_email(
         server.sendmail(settings.sender, recipients, message.as_string())
 
 
-def send_dingtalk_message(payload: dict[str, Any]) -> None:
+def send_dingtalk_message(payload: dict[str, Any]) -> str:
     webhook_url = _get_dingtalk_webhook()
     response = requests.post(webhook_url, json=payload, timeout=10)
     response.raise_for_status()
+    return webhook_url

--- a/models.py
+++ b/models.py
@@ -111,6 +111,12 @@ class MonitorTask(Base):
         cascade="all, delete-orphan",
         order_by="desc(CrawlResult.created_at)",
     )
+    notification_logs: Mapped[List["NotificationLog"]] = relationship(
+        "NotificationLog",
+        back_populates="task",
+        cascade="all, delete-orphan",
+        order_by="desc(NotificationLog.created_at)",
+    )
 
 
 class NotificationSetting(Base):
@@ -175,4 +181,18 @@ class CrawlLogDetail(Base):
     message: Mapped[str] = mapped_column(Text, nullable=False)
 
     log: Mapped[CrawlLog] = relationship("CrawlLog", back_populates="entries")
+
+
+class NotificationLog(Base):
+    __tablename__ = "notification_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    task_id: Mapped[int | None] = mapped_column(ForeignKey("monitor_tasks.id"), nullable=True)
+    channel: Mapped[str] = mapped_column(String(50), nullable=False)
+    target: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    task: Mapped[MonitorTask | None] = relationship("MonitorTask", back_populates="notification_logs")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,9 @@
       </div>
     </nav>
     <div class="container">
+      <div class="alert alert-light border rounded-1 py-2 small" role="note">
+        平台时间均以：<strong>{{ current_timezone_display }}</strong> 为准。
+      </div>
       {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
           {% for category, message in messages %}

--- a/templates/contents/list.html
+++ b/templates/contents/list.html
@@ -66,7 +66,7 @@
           <tr>
             <td>{{ content.text }}</td>
             <td>{{ content.category.name }}</td>
-            <td>{{ content.created_at }}</td>
+            <td>{{ content.created_at|format_datetime }}</td>
             <td>
               <form action="{{ url_for('delete_content', content_id=content.id) }}" method="post" onsubmit="return confirm('确认删除该关注内容？');">
                 <button class="btn btn-sm btn-danger">删除</button>

--- a/templates/notifications/manage.html
+++ b/templates/notifications/manage.html
@@ -56,4 +56,68 @@
     </div>
   </div>
 </div>
+
+<div class="card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <span>发送日志</span>
+    <span class="badge text-bg-secondary">共 {{ log_total }} 条</span>
+  </div>
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-striped mb-0">
+        <thead>
+          <tr>
+            <th scope="col" style="width: 20%;">时间</th>
+            <th scope="col" style="width: 15%;">渠道</th>
+            <th scope="col">目标</th>
+            <th scope="col" style="width: 10%;">状态</th>
+            <th scope="col">说明</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for log in notification_logs %}
+          <tr>
+            <td>{{ log.created_at|format_datetime or '未知' }}</td>
+            <td>{{ '邮件' if log.channel == 'email' else '钉钉' }}</td>
+            <td class="text-truncate" style="max-width: 260px;" title="{{ log.target }}">{{ log.target or '未提供' }}</td>
+            <td>
+              {% if log.status == 'success' %}
+              <span class="badge text-bg-success">成功</span>
+              {% elif log.status == 'failed' %}
+              <span class="badge text-bg-danger">失败</span>
+              {% else %}
+              <span class="badge text-bg-secondary">{{ log.status }}</span>
+              {% endif %}
+            </td>
+            <td>{{ log.message or '—' }}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="5" class="text-center text-muted py-4">暂无发送记录</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {% if log_total_pages > 1 %}
+  <div class="card-footer">
+    <nav aria-label="发送日志分页">
+      <ul class="pagination justify-content-center mb-0">
+        <li class="page-item {% if log_page <= 1 %}disabled{% endif %}">
+          <a class="page-link" href="{{ url_for('manage_notifications', page=log_page-1) }}" tabindex="-1">上一页</a>
+        </li>
+        {% for p in range(1, log_total_pages + 1) %}
+        <li class="page-item {% if p == log_page %}active{% endif %}">
+          <a class="page-link" href="{{ url_for('manage_notifications', page=p) }}">{{ p }}</a>
+        </li>
+        {% endfor %}
+        <li class="page-item {% if log_page >= log_total_pages %}disabled{% endif %}">
+          <a class="page-link" href="{{ url_for('manage_notifications', page=log_page+1) }}">下一页</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  {% endif %}
+</div>
 {% endblock %}

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -48,9 +48,9 @@
         <h5 class="card-title">执行与通知</h5>
         <p class="mb-1"><strong>任务状态：</strong> {{ '运行中' if task.is_active else '已暂停' }}</p>
         <p class="mb-1"><strong>最近执行状态：</strong> {{ status_styles.get(task.last_status, ('secondary', task.last_status or '无'))[1] }}</p>
-        <p class="mb-1"><strong>最近执行时间：</strong> {{ task.last_run_at or '无' }}</p>
+        <p class="mb-1"><strong>最近执行时间：</strong> {{ task.last_run_at|format_datetime or '无' }}</p>
         {% if next_run_at %}
-        <p class="mb-1"><strong>下一次执行时间：</strong> {{ next_run_at.strftime('%Y-%m-%d %H:%M:%S') }}</p>
+        <p class="mb-1"><strong>下一次执行时间：</strong> {{ next_run_at|format_datetime }}</p>
         {% elif task.is_active and not active_log %}
         <p class="mb-1 text-muted"><strong>下一次执行时间：</strong> 调度将在配置的间隔内自动安排</p>
         {% endif %}
@@ -82,8 +82,8 @@
             <div class="d-flex flex-grow-1 flex-wrap align-items-center gap-2">
               <span class="badge text-bg-{{ status[0] }}" data-log-status>{{ status[1] }}</span>
               <span class="text-muted small">编号：{{ log.id }}</span>
-              <span class="text-muted small">开始：{{ log.run_started_at or '未知' }}</span>
-              <span class="text-muted small">结束：<span data-log-finished>{{ log.run_finished_at or (log.status == 'running' and '进行中' or '未知') }}</span></span>
+              <span class="text-muted small">开始：{{ log.run_started_at|format_datetime or '未知' }}</span>
+              <span class="text-muted small">结束：<span data-log-finished>{{ log.run_finished_at|format_datetime or (log.status == 'running' and '进行中' or '未知') }}</span></span>
               <span class="text-muted small text-truncate">{{ log.message or '暂无汇总信息' }}</span>
             </div>
           </button>
@@ -95,7 +95,7 @@
               {% for entry in log.entries %}
               <li class="mb-2" data-entry-id="{{ entry.id }}">
                 <span class="badge text-bg-secondary me-2">{{ entry.level|upper }}</span>
-                <small class="text-muted me-2">{{ entry.created_at }}</small>
+                <small class="text-muted me-2">{{ entry.created_at|format_datetime }}</small>
                 {{ entry.message }}
               </li>
               {% else %}
@@ -140,7 +140,7 @@
   <tbody>
     {% for result in results %}
     <tr>
-      <td>{{ result.created_at }}</td>
+      <td>{{ result.created_at|format_datetime }}</td>
       <td>{{ result.link_title or '无标题' }}</td>
       <td><a href="{{ result.discovered_url }}" target="_blank">打开</a></td>
       <td>{{ result.content.text if result.content else '未知' }}</td>


### PR DESCRIPTION
## Summary
- add database model and crawler hooks to persist email and DingTalk notification send results
- enhance notification settings page with paginated delivery log table and timezone notice
- render timestamps with explicit timezone details across views and API responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd303100e08320bd56a75c8bec8c88