### PR TITLE
Add notification test triggers and improve logging

### DIFF
--- a/templates/notifications/manage.html
+++ b/templates/notifications/manage.html
@@ -7,7 +7,7 @@
     <div class="card mb-4">
       <div class="card-header">SMTP 邮件配置</div>
       <div class="card-body">
-        <form method="post">
+        <form method="post" class="d-grid gap-3">
           <input type="hidden" name="config_type" value="email">
           <div class="mb-3">
             <label class="form-label">SMTP 主机</label>
@@ -34,7 +34,14 @@
             <input class="form-check-input" type="checkbox" id="smtpUseTls" name="smtp_use_tls" {% if not email_setting or email_setting.smtp_use_tls %}checked{% endif %}>
             <label class="form-check-label" for="smtpUseTls">启用 TLS</label>
           </div>
-          <button class="btn btn-primary" type="submit">保存 SMTP 配置</button>
+          <div class="mb-3">
+            <label class="form-label">测试收件人（可选）</label>
+            <input type="email" class="form-control" name="test_recipient" placeholder="未填写则默认使用发件人地址">
+          </div>
+          <div class="d-flex gap-2">
+            <button class="btn btn-primary" type="submit" name="action" value="save">保存 SMTP 配置</button>
+            <button class="btn btn-outline-secondary" type="submit" name="action" value="test">发送测试邮件</button>
+          </div>
         </form>
       </div>
     </div>
@@ -43,14 +50,17 @@
     <div class="card mb-4">
       <div class="card-header">钉钉机器人配置</div>
       <div class="card-body">
-        <form method="post">
+        <form method="post" class="d-grid gap-3">
           <input type="hidden" name="config_type" value="dingtalk">
           <div class="mb-3">
             <label class="form-label">Webhook 地址</label>
             <input type="url" class="form-control" name="webhook_url" value="{{ dingtalk_setting.webhook_url if dingtalk_setting else '' }}" required>
           </div>
-          <div class="form-text mb-3">请使用钉钉群机器人提供的自定义机器人 webhook 地址。</div>
-          <button class="btn btn-primary" type="submit">保存钉钉配置</button>
+          <div class="form-text">请使用钉钉群机器人提供的自定义机器人 webhook 地址。</div>
+          <div class="d-flex gap-2">
+            <button class="btn btn-primary" type="submit" name="action" value="save">保存钉钉配置</button>
+            <button class="btn btn-outline-secondary" type="submit" name="action" value="test">发送测试通知</button>
+          </div>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- log notification send attempts in crawler run details and email/dingtalk helpers
- add test actions for email and DingTalk configuration forms with sample payloads
- provide recipient validation and optional test recipient input for email tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd34d3de4c83208345bbcf9079b95f