### PR TITLE
Update DingTalk test notification payload

### DIFF
--- a/app.py
+++ b/app.py
@@ -491,8 +491,22 @@ def manage_notifications() -> Any:
                 try:
                     webhook_url = send_dingtalk_message(
                         {
-                            "msgtype": "text",
-                            "text": {"content": "【测试】政策监控钉钉通知已触发"},
+                            "msgtype": "feedCard",
+                            "title": "测试数据",
+                            "feedCard": {
+                                "links": [
+                                    {
+                                        "title": "测试标题1",
+                                        "messageURL": "https://www.dingtalk.com/",
+                                        "picURL": "https://img.alicdn.com/tfs/TB1NwmBEL9TBuNjy1zbXXXpepXa-2400-1218.png",
+                                    },
+                                    {
+                                        "title": "测试标题2",
+                                        "messageURL": "https://www.dingtalk.com/",
+                                        "picURL": "https://img.alicdn.com/tfs/TB1NwmBEL9TBuNjy1zbXXXpepXa-2400-1218.png",
+                                    },
+                                ]
+                            },
                         }
                     )
                 except NotificationConfigError as exc:


### PR DESCRIPTION
## Summary
- update the test DingTalk notification payload to use the provided feed card template

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3f4ca19c83208604d3aab63715bf