### PR TITLE
Update DingTalk test payload for notification testing

### DIFF
--- a/app.py
+++ b/app.py
@@ -492,7 +492,7 @@ def manage_notifications() -> Any:
                     webhook_url = send_dingtalk_message(
                         {
                             "msgtype": "feedCard",
-                            "title": "测试数据",
+                            "title": "\u00a0【订阅】测试数据",
                             "feedCard": {
                                 "links": [
                                     {


### PR DESCRIPTION
## Summary
- update the DingTalk notification test payload to match the latest feed card JSON requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd4119b8b083208e3a2e795226aadf