### PR TITLE
Add log cleanup actions and notification previews

### DIFF
--- a/database.py
+++ b/database.py
@@ -31,3 +31,12 @@ def init_db() -> None:
             connection.exec_driver_sql(
                 "ALTER TABLE websites ADD COLUMN content_selector_config TEXT"
             )
+
+        notification_columns = {
+            row[1]
+            for row in connection.exec_driver_sql("PRAGMA table_info(notification_logs)").fetchall()
+        }
+        if "payload" not in notification_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE notification_logs ADD COLUMN payload TEXT"
+            )

--- a/models.py
+++ b/models.py
@@ -192,6 +192,7 @@ class NotificationLog(Base):
     target: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False)
     message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    payload: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     task: Mapped[MonitorTask | None] = relationship("MonitorTask", back_populates="notification_logs")

--- a/templates/notifications/manage.html
+++ b/templates/notifications/manage.html
@@ -69,66 +69,83 @@
 
 <div class="card">
   <div class="card-header d-flex justify-content-between align-items-center">
-    <span>发送日志</span>
-    <span class="badge text-bg-secondary">共 {{ log_total }} 条</span>
-  </div>
-  <div class="card-body p-0">
-    <div class="table-responsive">
-      <table class="table table-striped mb-0">
-        <thead>
-          <tr>
-            <th scope="col" style="width: 20%;">时间</th>
-            <th scope="col" style="width: 15%;">渠道</th>
-            <th scope="col">目标</th>
-            <th scope="col" style="width: 10%;">状态</th>
-            <th scope="col">说明</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for log in notification_logs %}
-          <tr>
-            <td>{{ log.created_at|format_datetime or '未知' }}</td>
-            <td>{{ '邮件' if log.channel == 'email' else '钉钉' }}</td>
-            <td class="text-truncate" style="max-width: 260px;" title="{{ log.target }}">{{ log.target or '未提供' }}</td>
-            <td>
-              {% if log.status == 'success' %}
-              <span class="badge text-bg-success">成功</span>
-              {% elif log.status == 'failed' %}
-              <span class="badge text-bg-danger">失败</span>
-              {% else %}
-              <span class="badge text-bg-secondary">{{ log.status }}</span>
-              {% endif %}
-            </td>
-            <td>
-              {% if log.message %}
-              <button
-                type="button"
-                class="btn btn-link p-0 align-baseline"
-                data-bs-toggle="modal"
-                data-bs-target="#logMessageModal"
-                data-message="{{ log.message|e }}"
-                data-channel-label="{{ '邮件' if log.channel == 'email' else '钉钉' }}"
-                data-status-label="{{ '成功' if log.status == 'success' else '失败' if log.status == 'failed' else log.status }}"
-                data-target="{{ (log.target or '')|e }}"
-                data-created-at="{{ log.created_at|format_datetime or '' }}"
-                title="点击查看详情"
-              >
-                {{ log.message|truncate(32, True, '…') }}
-              </button>
-              {% else %}
-              —
-              {% endif %}
-            </td>
-          </tr>
-          {% else %}
-          <tr>
-            <td colspan="5" class="text-center text-muted py-4">暂无发送记录</td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+    <div class="d-flex align-items-center gap-2">
+      <span>发送日志</span>
+      <span class="badge text-bg-secondary">共 {{ log_total }} 条</span>
     </div>
+    <button type="submit" form="notificationLogForm" class="btn btn-sm btn-outline-danger" id="deleteLogsButton" onclick="return confirm('确定删除选中的通知日志吗？');" {% if not notification_logs %}disabled{% endif %}>删除选中</button>
   </div>
+  <form id="notificationLogForm" method="post" action="{{ url_for('delete_notification_logs') }}">
+    <input type="hidden" name="current_page" value="{{ log_page }}">
+    <div class="card-body p-0">
+      <div class="table-responsive">
+        <table class="table table-striped mb-0 align-middle">
+          <thead>
+            <tr>
+              <th scope="col" class="text-center" style="width: 4%;">
+                <input class="form-check-input" type="checkbox" id="selectAllLogs" {% if not notification_logs %}disabled{% endif %}>
+              </th>
+              <th scope="col" style="width: 18%;">时间</th>
+              <th scope="col" style="width: 15%;">渠道</th>
+              <th scope="col">目标</th>
+              <th scope="col" style="width: 10%;">状态</th>
+              <th scope="col">详情</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for log in notification_logs %}
+            <tr>
+              <td class="text-center">
+                <input class="form-check-input log-checkbox" type="checkbox" name="log_ids" value="{{ log.id }}">
+              </td>
+              <td>{{ log.created_at|format_datetime or '未知' }}</td>
+              <td>{{ '邮件' if log.channel == 'email' else '钉钉' }}</td>
+              <td class="text-truncate" style="max-width: 260px;" title="{{ log.target }}">{{ log.target or '未提供' }}</td>
+              <td>
+                {% if log.status == 'success' %}
+                <span class="badge text-bg-success">成功</span>
+                {% elif log.status == 'failed' %}
+                <span class="badge text-bg-danger">失败</span>
+                {% else %}
+                <span class="badge text-bg-secondary">{{ log.status }}</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if log.message or log.payload %}
+                <button
+                  type="button"
+                  class="btn btn-link p-0 align-baseline"
+                  data-bs-toggle="modal"
+                  data-bs-target="#logMessageModal"
+                  data-message="{{ (log.message or '')|e }}"
+                  data-payload='{{ log.payload|tojson|safe }}'
+                  data-channel-label="{{ '邮件' if log.channel == 'email' else '钉钉' }}"
+                  data-status-label="{{ '成功' if log.status == 'success' else '失败' if log.status == 'failed' else log.status }}"
+                  data-target="{{ (log.target or '')|e }}"
+                  data-created-at="{{ log.created_at|format_datetime or '' }}"
+                  title="点击查看详情"
+                >
+                  {% if log.message %}
+                  {{ log.message|truncate(32, True, '…') }}
+                  {% else %}
+                  查看内容
+                  {% endif %}
+                </button>
+                {% else %}
+                —
+                {% endif %}
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="6" class="text-center text-muted py-4">暂无发送记录</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </form>
   {% if log_total_pages > 1 %}
   <div class="card-footer">
     <nav aria-label="发送日志分页">
@@ -159,7 +176,14 @@
       </div>
       <div class="modal-body">
         <p class="text-muted small" id="logMessageModalMeta"></p>
-        <pre id="logMessageModalBody" class="bg-light border rounded p-3 mb-0" style="white-space: pre-wrap;"></pre>
+        <div id="logMessageContainer" class="mb-3 d-none">
+          <h6 class="fw-semibold">状态说明</h6>
+          <pre id="logMessageModalBody" class="bg-light border rounded p-3 mb-0" style="white-space: pre-wrap;"></pre>
+        </div>
+        <div id="logPayloadContainer" class="d-none">
+          <h6 class="fw-semibold">发送内容预览</h6>
+          <div id="logPayloadPreview" class="border rounded bg-white"></div>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">关闭</button>
@@ -179,7 +203,11 @@
       var modalTitle = messageModal.querySelector('.modal-title');
       var modalMeta = document.getElementById('logMessageModalMeta');
       var modalBody = document.getElementById('logMessageModalBody');
+      var messageContainer = document.getElementById('logMessageContainer');
+      var payloadContainer = document.getElementById('logPayloadContainer');
+      var payloadPreview = document.getElementById('logPayloadPreview');
       var message = trigger ? trigger.getAttribute('data-message') || '' : '';
+      var rawPayload = trigger ? trigger.getAttribute('data-payload') || '' : '';
       var channelLabel = trigger ? trigger.getAttribute('data-channel-label') || '' : '';
       var statusLabel = trigger ? trigger.getAttribute('data-status-label') || '' : '';
       var target = trigger ? trigger.getAttribute('data-target') || '' : '';
@@ -191,8 +219,104 @@
       if (statusLabel) metaItems.push('状态：' + statusLabel);
       if (target) metaItems.push('目标：' + target);
       modalMeta.textContent = metaItems.join(' · ');
-      modalBody.textContent = message || '无详细信息';
+      if (messageContainer) {
+        if (message) {
+          messageContainer.classList.remove('d-none');
+          modalBody.textContent = message;
+        } else {
+          messageContainer.classList.add('d-none');
+          modalBody.textContent = '';
+        }
+      }
+
+      if (payloadContainer && payloadPreview) {
+        payloadContainer.classList.add('d-none');
+        payloadPreview.innerHTML = '';
+        if (rawPayload && rawPayload !== 'null') {
+          var parsedPayload = null;
+          try {
+            var payloadString = JSON.parse(rawPayload);
+            if (payloadString) {
+              try {
+                parsedPayload = JSON.parse(payloadString);
+              } catch (innerErr) {
+                parsedPayload = payloadString;
+              }
+            }
+          } catch (err) {
+            parsedPayload = null;
+          }
+
+          if (parsedPayload) {
+            payloadContainer.classList.remove('d-none');
+            if (typeof parsedPayload === 'object' && !Array.isArray(parsedPayload)) {
+              if (parsedPayload.recipients && parsedPayload.recipients.length) {
+                var recipientsEl = document.createElement('p');
+                recipientsEl.className = 'small text-muted mb-2';
+                recipientsEl.textContent = '收件人：' + parsedPayload.recipients.join(', ');
+                payloadPreview.appendChild(recipientsEl);
+              }
+              if (parsedPayload.format === 'email' && parsedPayload.html) {
+                var iframe = document.createElement('iframe');
+                iframe.className = 'w-100 border';
+                iframe.style.minHeight = '240px';
+                iframe.setAttribute('sandbox', '');
+                iframe.srcdoc = parsedPayload.html;
+                payloadPreview.appendChild(iframe);
+              } else {
+                var pre = document.createElement('pre');
+                pre.className = 'mb-0 bg-light border rounded p-3';
+                pre.style.whiteSpace = 'pre-wrap';
+                pre.textContent = JSON.stringify(parsedPayload, null, 2);
+                payloadPreview.appendChild(pre);
+              }
+            } else {
+              var textPre = document.createElement('pre');
+              textPre.className = 'mb-0 bg-light border rounded p-3';
+              textPre.style.whiteSpace = 'pre-wrap';
+              textPre.textContent = String(parsedPayload);
+              payloadPreview.appendChild(textPre);
+            }
+          }
+        }
+      }
     });
+
+    var logForm = document.getElementById('notificationLogForm');
+    var deleteButton = document.getElementById('deleteLogsButton');
+    var selectAll = document.getElementById('selectAllLogs');
+    var checkboxList = logForm ? Array.prototype.slice.call(logForm.querySelectorAll('.log-checkbox')) : [];
+
+    function updateDeleteState() {
+      if (!deleteButton) {
+        return;
+      }
+      var anyChecked = checkboxList.some(function (item) { return item.checked; });
+      deleteButton.disabled = !anyChecked;
+    }
+
+    if (selectAll && checkboxList.length) {
+      selectAll.addEventListener('change', function () {
+        var checked = selectAll.checked;
+        checkboxList.forEach(function (item) {
+          item.checked = checked;
+        });
+        updateDeleteState();
+      });
+    }
+
+    checkboxList.forEach(function (checkbox) {
+      checkbox.addEventListener('change', function () {
+        if (selectAll && !checkbox.checked) {
+          selectAll.checked = false;
+        } else if (selectAll && checkboxList.every(function (item) { return item.checked; })) {
+          selectAll.checked = true;
+        }
+        updateDeleteState();
+      });
+    });
+
+    updateDeleteState();
   });
 </script>
 {% endblock %}

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -70,7 +70,22 @@
   </div>
 </div>
 
-<h3 class="h5">执行日志</h3>
+<div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+  <h3 class="h5 mb-0">执行日志</h3>
+  <div class="d-flex flex-wrap align-items-center gap-2 small text-muted">
+    <span>共 {{ total_logs }} 条</span>
+    <form class="row row-cols-lg-auto g-2 align-items-end" method="post" action="{{ url_for('bulk_delete_task_logs', task_id=task.id) }}">
+      <input type="hidden" name="current_page" value="{{ page }}">
+      <div class="col">
+        <label class="form-label mb-0">删除此时间及之前的日志</label>
+        <input type="datetime-local" class="form-control form-control-sm" name="cutoff" required>
+      </div>
+      <div class="col">
+        <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('确定删除选定时间之前的日志吗？');">批量删除</button>
+      </div>
+    </form>
+  </div>
+</div>
 {% if logs %}
   <div class="accordion" id="logAccordion">
     {% for log in logs %}
@@ -90,7 +105,13 @@
         </h2>
         <div id="log-body-{{ log.id }}" class="accordion-collapse collapse {% if is_running %}show{% endif %}" aria-labelledby="heading-{{ log.id }}" data-bs-parent="#logAccordion">
           <div class="accordion-body">
-            <p class="text-muted mb-3" data-log-message>{{ log.message or '暂无汇总信息' }}</p>
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+              <p class="text-muted mb-0 flex-grow-1" data-log-message>{{ log.message or '暂无汇总信息' }}</p>
+              <form method="post" action="{{ url_for('delete_task_log', task_id=task.id, log_id=log.id) }}" class="ms-auto">
+                <input type="hidden" name="current_page" value="{{ page }}">
+                <button type="submit" class="btn btn-sm btn-outline-danger" {% if is_running %}disabled title="执行中的日志暂时无法删除"{% else %}onclick="return confirm('确定删除该执行日志吗？');"{% endif %}>删除此日志</button>
+              </form>
+            </div>
             <ul class="list-unstyled mb-0 log-entry-list">
               {% for entry in log.entries %}
               <li class="mb-2" data-entry-id="{{ entry.id }}">

--- a/tests/test_notification_logs.py
+++ b/tests/test_notification_logs.py
@@ -1,0 +1,57 @@
+import json
+import unittest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import record_notification_log  # noqa: E402
+from models import NotificationLog  # noqa: E402
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.added: list[NotificationLog] = []
+        self.commit_count = 0
+
+    def add(self, obj: NotificationLog) -> None:  # pragma: no cover - simple delegator
+        self.added.append(obj)
+
+    def commit(self) -> None:  # pragma: no cover - simple delegator
+        self.commit_count += 1
+
+
+class NotificationLogPayloadTestCase(unittest.TestCase):
+    def test_record_notification_log_stores_payload_json(self) -> None:
+        payload = {
+            "format": "email",
+            "subject": "测试",
+            "html": "<p>示例</p>",
+            "recipients": ["user@example.com"],
+        }
+        session = DummySession()
+
+        record_notification_log(
+            session,
+            channel="email",
+            status="success",
+            target="user@example.com",
+            message="发送成功",
+            payload=payload,
+        )
+
+        self.assertEqual(session.commit_count, 1)
+        self.assertEqual(len(session.added), 1)
+        stored = session.added[0]
+        self.assertIsInstance(stored, NotificationLog)
+        self.assertIsNotNone(stored.payload)
+        parsed = json.loads(stored.payload or "{}")
+        self.assertEqual(parsed.get("format"), "email")
+        self.assertEqual(parsed.get("subject"), "测试")
+        self.assertEqual(parsed.get("recipients"), ["user@example.com"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- capture notification payloads in the database so logs include message details
- add endpoints and UI to delete individual or time-ranged task execution logs
- enhance notification log management with bulk deletion, content preview, and supporting tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df4827f7908320b783467ff0d01687