### PR TITLE
Reduce Playwright warning noise when Playwright is missing

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -35,6 +35,7 @@ from nlp import similarity
 
 SIMILARITY_THRESHOLD = 0.6
 LOGGER = logging.getLogger(__name__)
+_PLAYWRIGHT_IMPORT_FAILED = False
 
 
 def _is_non_empty_text(value: str | None) -> bool:
@@ -222,6 +223,8 @@ def _fetch_html_with_requests(url: str) -> str:
 
 
 def fetch_html(url: str) -> str:
+    global _PLAYWRIGHT_IMPORT_FAILED
+
     try:
         from playwright.sync_api import (  # type: ignore import-not-found
             Error as PlaywrightError,
@@ -229,7 +232,9 @@ def fetch_html(url: str) -> str:
             sync_playwright,
         )
     except ImportError:
-        LOGGER.warning("Playwright 未安装，回退到 requests 抓取 %s", url)
+        if not _PLAYWRIGHT_IMPORT_FAILED:
+            LOGGER.info("Playwright 未安装，回退到 requests 抓取，后续请求将继续使用 requests")
+            _PLAYWRIGHT_IMPORT_FAILED = True
         return _fetch_html_with_requests(url)
 
     browser = None


### PR DESCRIPTION
## Summary
- log the missing Playwright dependency only once and downgrade the log level to info when falling back to requests
- reuse the requests fallback for subsequent fetches without repeating the warning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df5eed4e588320b1ab775cec0d70b4