### PR TITLE
Add ability to clear website snapshots

### DIFF
--- a/app.py
+++ b/app.py
@@ -173,6 +173,25 @@ def view_website_snapshot(website_id: int) -> Any:
         session.close()
 
 
+@app.route("/websites/<int:website_id>/snapshot/clear", methods=["POST"])
+def clear_website_snapshot(website_id: int) -> Any:
+    session = SessionLocal()
+    try:
+        website = session.get(Website, website_id)
+        if not website:
+            flash("未找到网站", "danger")
+            return redirect(url_for("list_websites"))
+
+        website.last_snapshot = None
+        website.last_fetched_at = None
+        session.add(website)
+        session.commit()
+        flash("已清空网站快照", "success")
+        return redirect(url_for("list_websites"))
+    finally:
+        session.close()
+
+
 @app.route("/websites/new", methods=["GET", "POST"])
 def create_website() -> Any:
     session = SessionLocal()

--- a/templates/websites/snapshot.html
+++ b/templates/websites/snapshot.html
@@ -4,6 +4,13 @@
   <h2 class="mb-0">网站快照 - {{ website.name }}</h2>
   <div class="d-flex flex-wrap gap-2">
     <a class="btn btn-secondary" href="{{ url_for('list_websites') }}">返回网站列表</a>
+    <form
+      method="post"
+      action="{{ url_for('clear_website_snapshot', website_id=website.id) }}"
+      onsubmit="return confirm('确认清空该网站的历史快照？');"
+    >
+      <button type="submit" class="btn btn-danger">清空快照</button>
+    </form>
     {% if related_tasks %}
       {% for task in related_tasks %}
       <a class="btn btn-outline-primary" href="{{ url_for('view_task', task_id=task.id) }}">{{ task.name }}</a>

--- a/tests/test_snapshot_routes.py
+++ b/tests/test_snapshot_routes.py
@@ -1,0 +1,62 @@
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+import app
+from database import Base, SessionLocal, engine
+from models import Website
+
+
+class WebsiteSnapshotRoutesTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = Path("data.db")
+        engine.dispose()
+        if self.db_path.exists():
+            self.db_path.unlink()
+        Base.metadata.create_all(bind=engine)
+        self.original_setup_flag = app._setup_complete
+        app._setup_complete = True
+        app.app.testing = True
+        self.client = app.app.test_client()
+
+    def tearDown(self) -> None:
+        SessionLocal.remove()
+        engine.dispose()
+        Base.metadata.drop_all(bind=engine)
+        if self.db_path.exists():
+            self.db_path.unlink()
+        app._setup_complete = self.original_setup_flag
+
+    def test_clear_snapshot_resets_state(self) -> None:
+        session = SessionLocal()
+        website = Website(
+            name="Example",
+            url="https://example.com",
+            last_snapshot="{}",
+            last_fetched_at=datetime.utcnow(),
+        )
+        session.add(website)
+        session.commit()
+        website_id = website.id
+        session.close()
+
+        response = self.client.post(
+            f"/websites/{website_id}/snapshot/clear",
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+
+        session = SessionLocal()
+        refreshed = session.get(Website, website_id)
+        session.close()
+
+        self.assertIsNotNone(refreshed)
+        assert refreshed is not None
+        self.assertIsNone(refreshed.last_snapshot)
+        self.assertIsNone(refreshed.last_fetched_at)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add an endpoint to clear stored snapshots and reset website fetch timestamps
- expose the clear snapshot action from the snapshot detail view
- cover the snapshot reset workflow with a route-level unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df74956d2c83209c2067b897a8a38b