### PR TITLE
Add JSON API monitoring option

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,12 @@ def create_website() -> Any:
         title_selectors = request.form.get("title_selectors", "").strip()
         content_selectors = request.form.get("content_selectors", "").strip()
         content_area_selectors = request.form.get("content_area_selectors", "").strip()
+        is_json_api = bool(request.form.get("is_json_api"))
+        api_list_path = request.form.get("api_list_path", "").strip()
+        api_title_path = request.form.get("api_title_path", "").strip()
+        api_url_path = request.form.get("api_url_path", "").strip()
+        api_url_template = request.form.get("api_url_template", "").strip()
+        api_detail_url_base = request.form.get("api_detail_url_base", "").strip()
         if not name or not url:
             flash("请输入网站名称和URL", "danger")
         else:
@@ -214,6 +220,12 @@ def create_website() -> Any:
                 title_selector_config=title_selectors or None,
                 content_selector_config=content_selectors or None,
                 content_area_selector_config=content_area_selectors or None,
+                is_json_api=is_json_api,
+                api_list_path=api_list_path or None,
+                api_title_path=api_title_path or None,
+                api_url_path=api_url_path or None,
+                api_url_template=api_url_template or None,
+                api_detail_url_base=api_detail_url_base or None,
             )
             session.add(website)
             session.commit()
@@ -243,6 +255,12 @@ def edit_website(website_id: int) -> Any:
         website.content_area_selector_config = (
             request.form.get("content_area_selectors", "").strip() or None
         )
+        website.is_json_api = bool(request.form.get("is_json_api"))
+        website.api_list_path = request.form.get("api_list_path", "").strip() or None
+        website.api_title_path = request.form.get("api_title_path", "").strip() or None
+        website.api_url_path = request.form.get("api_url_path", "").strip() or None
+        website.api_url_template = request.form.get("api_url_template", "").strip() or None
+        website.api_detail_url_base = request.form.get("api_detail_url_base", "").strip() or None
         session.add(website)
         session.commit()
         flash("网站信息已更新", "success")

--- a/database.py
+++ b/database.py
@@ -35,6 +35,30 @@ def init_db() -> None:
             connection.exec_driver_sql(
                 "ALTER TABLE websites ADD COLUMN content_area_selector_config TEXT"
             )
+        if "is_json_api" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN is_json_api BOOLEAN DEFAULT 0"
+            )
+        if "api_list_path" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN api_list_path TEXT"
+            )
+        if "api_title_path" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN api_title_path TEXT"
+            )
+        if "api_url_path" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN api_url_path TEXT"
+            )
+        if "api_url_template" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN api_url_template TEXT"
+            )
+        if "api_detail_url_base" not in existing_columns:
+            connection.exec_driver_sql(
+                "ALTER TABLE websites ADD COLUMN api_detail_url_base TEXT"
+            )
 
         notification_columns = {
             row[1]

--- a/models.py
+++ b/models.py
@@ -41,6 +41,12 @@ class Website(Base):
     title_selector_config: Mapped[str | None] = mapped_column(Text, nullable=True)
     content_selector_config: Mapped[str | None] = mapped_column(Text, nullable=True)
     content_area_selector_config: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_json_api: Mapped[bool] = mapped_column(Boolean, default=False)
+    api_list_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    api_title_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    api_url_path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    api_url_template: Mapped[str | None] = mapped_column(Text, nullable=True)
+    api_detail_url_base: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     tasks: Mapped[List["MonitorTask"]] = relationship("MonitorTask", back_populates="website")
 

--- a/templates/websites/form.html
+++ b/templates/websites/form.html
@@ -15,6 +15,11 @@
     <input type="number" class="form-control" name="interval" min="1" value="{{ website.interval_minutes if website else 60 }}">
   </div>
 
+  <div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" name="is_json_api" id="isJsonApi" {% if website and website.is_json_api %}checked{% endif %}>
+    <label class="form-check-label" for="isJsonApi">使用 JSON API 列表数据</label>
+  </div>
+
   <div class="card border-0 shadow-sm mb-4">
     <div class="card-header bg-light fw-semibold">列表页配置</div>
     <div class="card-body">
@@ -24,6 +29,37 @@
         </label>
         <textarea class="form-control" name="content_area_selectors" rows="3" placeholder="例如：css=#main .article-list 或 xpath=//section[@data-type='policy']">{{ website.content_area_selector_config if website and website.content_area_selector_config else '' }}</textarea>
         <div class="form-text">每行一条规则，与标题和正文定位的写法一致，按顺序匹配第一个找到的区域。</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="jsonApiConfig" class="card border-0 shadow-sm mb-4{% if not (website and website.is_json_api) %} d-none{% endif %}">
+    <div class="card-header bg-light fw-semibold">JSON API 配置</div>
+    <div class="card-body">
+      <div class="mb-3">
+        <label class="form-label">数据列表路径</label>
+        <input type="text" class="form-control" name="api_list_path" placeholder="例如：data.items 或 records" value="{{ website.api_list_path if website and website.api_list_path else '' }}">
+        <div class="form-text">按点号分隔的路径，可使用如 <code>data.items[0]</code> 的下标访问，留空表示直接使用顶层数组。</div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">标题字段路径</label>
+        <input type="text" class="form-control" name="api_title_path" placeholder="例如：title 或 attributes.name" value="{{ website.api_title_path if website and website.api_title_path else '' }}">
+        <div class="form-text">用于提取子页面标题的字段路径，支持点号与下标语法，留空则默认使用拼接后的链接作为标题。</div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">URL 字段路径</label>
+        <input type="text" class="form-control" name="api_url_path" placeholder="例如：detailUrl 或 data.id" value="{{ website.api_url_path if website and website.api_url_path else '' }}">
+        <div class="form-text">当未配置 URL 模板时，系统将读取该字段作为链接地址。</div>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">URL 模板</label>
+        <input type="text" class="form-control" name="api_url_template" placeholder="例如：https://example.com/detail/{id}" value="{{ website.api_url_template if website and website.api_url_template else '' }}">
+        <div class="form-text">可使用 <code>{字段路径}</code> 语法引用列表项字段，例如 <code>{data.id}</code>。若模板返回相对路径，将自动与下方基准地址或网站 URL 拼接。</div>
+      </div>
+      <div class="mb-0">
+        <label class="form-label">详情页基准地址</label>
+        <input type="text" class="form-control" name="api_detail_url_base" placeholder="例如：https://example.com/" value="{{ website.api_detail_url_base if website and website.api_detail_url_base else '' }}">
+        <div class="form-text">当生成的链接为相对路径时，将使用该地址作为基准；留空时默认使用网站 URL。</div>
       </div>
     </div>
   </div>
@@ -58,17 +94,30 @@
   document.addEventListener('DOMContentLoaded', function () {
     var fetchSubpagesCheckbox = document.getElementById('fetchSubpages');
     var detailSelectors = document.getElementById('detailSelectors');
+    var isJsonApiCheckbox = document.getElementById('isJsonApi');
+    var jsonApiConfig = document.getElementById('jsonApiConfig');
 
     function toggleDetailSelectors() {
-      if (fetchSubpagesCheckbox.checked) {
+      if (fetchSubpagesCheckbox.checked || isJsonApiCheckbox.checked) {
         detailSelectors.classList.remove('d-none');
       } else {
         detailSelectors.classList.add('d-none');
       }
     }
 
+    function toggleJsonApiConfig() {
+      if (isJsonApiCheckbox.checked) {
+        jsonApiConfig.classList.remove('d-none');
+      } else {
+        jsonApiConfig.classList.add('d-none');
+      }
+      toggleDetailSelectors();
+    }
+
     toggleDetailSelectors();
+    toggleJsonApiConfig();
     fetchSubpagesCheckbox.addEventListener('change', toggleDetailSelectors);
+    isJsonApiCheckbox.addEventListener('change', toggleJsonApiConfig);
   });
 </script>
 

--- a/templates/websites/list.html
+++ b/templates/websites/list.html
@@ -10,6 +10,7 @@
     <tr>
       <th>名称</th>
       <th>URL</th>
+      <th>来源类型</th>
       <th>抓取子页面</th>
       <th>时间间隔(分钟)</th>
       <th>最后抓取时间</th>
@@ -26,6 +27,7 @@
       <td>
         <a href="{{ website.url }}" target="_blank" rel="noopener noreferrer">访问网站</a>
       </td>
+      <td>{{ 'JSON API' if website.is_json_api else '网页' }}</td>
       <td>{{ '是' if website.fetch_subpages else '否' }}</td>
       <td>{{ website.interval_minutes }}</td>
       <td>{{ website.last_fetched_at or '尚未抓取' }}</td>

--- a/tests/test_json_api_support.py
+++ b/tests/test_json_api_support.py
@@ -1,0 +1,72 @@
+from crawler import (
+    _lookup_json_path,
+    _render_api_template,
+    _load_previous_api_urls,
+    build_json_api_snapshot,
+    parse_snapshot,
+)
+
+
+def test_lookup_json_path_supports_nested_and_index_access():
+    data = {
+        "data": {
+            "items": [
+                {"id": 1, "info": {"title": "First"}},
+                {"id": 2, "info": {"title": "Second"}},
+            ]
+        }
+    }
+
+    assert _lookup_json_path(data, "data.items[0].info.title") == "First"
+    assert _lookup_json_path(data, "data.items[1].id") == 2
+    assert _lookup_json_path(data, "") == data
+    assert _lookup_json_path(data, "data.missing") is None
+
+
+def test_render_api_template_replaces_placeholders_with_path_values():
+    item = {"id": 9, "meta": {"slug": "abc"}}
+    template = "https://example.com/{meta.slug}?id={id}&from={base_url}"
+    rendered = _render_api_template(template, item, "https://api.example.com/list")
+    assert rendered == "https://example.com/abc?id=9&from=https://api.example.com/list"
+
+
+def test_build_json_api_snapshot_integrates_with_parse_snapshot():
+    snapshot = build_json_api_snapshot(
+        api_raw="{\"items\": []}",
+        items=[
+            {
+                "url": "https://example.com/detail/1",
+                "title": "Detail Title",
+                "raw": {"id": 1, "title": "Detail Title"},
+            }
+        ],
+        detail_snapshots=[
+            {
+                "url": "https://example.com/detail/1",
+                "html": "<p>content</p>",
+                "title": "Detail Title",
+                "text": "content",
+            }
+        ],
+    )
+
+    main_html, entries, main_title, main_text = parse_snapshot(snapshot)
+
+    assert "items" in (main_html or "")
+    assert entries and entries[0]["url"] == "https://example.com/detail/1"
+    assert entries[0]["html"] == "<p>content</p>"
+    assert main_title is None
+    assert main_text is None
+
+
+def test_load_previous_api_urls_extracts_urls_from_snapshot():
+    snapshot = build_json_api_snapshot(
+        api_raw="{}",
+        items=[
+            {"url": "https://example.com/a", "title": "A"},
+            {"url": "https://example.com/b", "title": "B"},
+        ],
+    )
+
+    urls = _load_previous_api_urls(snapshot)
+    assert urls == {"https://example.com/a", "https://example.com/b"}


### PR DESCRIPTION
## Summary
- add JSON API configuration fields to website model and forms so API-based endpoints can be configured independently
- extend the crawler with a JSON API execution branch that fetches list data, builds detail URLs, and stores dedicated snapshots
- add tests covering JSON path helpers and snapshot serialization for the new API mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df8277d8ec83208218fcf0161fd1b9