### PR TITLE
Improve JSON API handling and website form toggles

### DIFF
--- a/templates/websites/form.html
+++ b/templates/websites/form.html
@@ -20,7 +20,7 @@
     <label class="form-check-label" for="isJsonApi">使用 JSON API 列表数据</label>
   </div>
 
-  <div class="card border-0 shadow-sm mb-4">
+  <div id="listConfig" class="card border-0 shadow-sm mb-4">
     <div class="card-header bg-light fw-semibold">列表页配置</div>
     <div class="card-body">
       <div class="mb-3 mb-md-0">
@@ -29,6 +29,28 @@
         </label>
         <textarea class="form-control" name="content_area_selectors" rows="3" placeholder="例如：css=#main .article-list 或 xpath=//section[@data-type='policy']">{{ website.content_area_selector_config if website and website.content_area_selector_config else '' }}</textarea>
         <div class="form-text">每行一条规则，与标题和正文定位的写法一致，按顺序匹配第一个找到的区域。</div>
+      </div>
+    </div>
+  </div>
+
+  <div id="detailConfig" class="card border-0 shadow-sm mb-4">
+    <div class="card-header bg-light fw-semibold">详情页配置</div>
+    <div class="card-body">
+      <div class="form-check form-switch mb-3">
+        <input class="form-check-input" type="checkbox" name="fetch_subpages" id="fetchSubpages" {% if website and website.fetch_subpages %}checked{% endif %}>
+        <label class="form-check-label" for="fetchSubpages">需要抓取子页面</label>
+      </div>
+      <div id="detailSelectors" class="detail-selectors{% if not (website and website.fetch_subpages) %} d-none{% endif %}">
+        <div class="mb-3">
+          <label class="form-label">标题元素描述</label>
+          <textarea class="form-control" name="title_selectors" rows="3" placeholder="例如：id=main-title 或 css=h1.article-title">{{ website.title_selector_config if website and website.title_selector_config else '' }}</textarea>
+          <div class="form-text">每行一条规则，支持 <code>id=</code>、<code>class=</code>、<code>name=</code>、<code>css=</code>、<code>xpath=</code> 等写法，按顺序优先匹配。</div>
+        </div>
+        <div class="mb-0">
+          <label class="form-label">正文元素描述</label>
+          <textarea class="form-control" name="content_selectors" rows="4" placeholder="例如：css=article .content 或 xpath=//div[@id='detail']">{{ website.content_selector_config if website and website.content_selector_config else '' }}</textarea>
+          <div class="form-text">若能匹配到对应元素，将直接使用其文本作为页面标题或正文；未匹配到时将自动回退到智能摘要，并忽略菜单及页脚文字。</div>
+        </div>
       </div>
     </div>
   </div>
@@ -64,28 +86,6 @@
     </div>
   </div>
 
-  <div class="card border-0 shadow-sm mb-4">
-    <div class="card-header bg-light fw-semibold">详情页配置</div>
-    <div class="card-body">
-      <div class="form-check form-switch mb-3">
-        <input class="form-check-input" type="checkbox" name="fetch_subpages" id="fetchSubpages" {% if website and website.fetch_subpages %}checked{% endif %}>
-        <label class="form-check-label" for="fetchSubpages">需要抓取子页面</label>
-      </div>
-      <div id="detailSelectors" class="detail-selectors{% if not (website and website.fetch_subpages) %} d-none{% endif %}">
-        <div class="mb-3">
-          <label class="form-label">标题元素描述</label>
-          <textarea class="form-control" name="title_selectors" rows="3" placeholder="例如：id=main-title 或 css=h1.article-title">{{ website.title_selector_config if website and website.title_selector_config else '' }}</textarea>
-          <div class="form-text">每行一条规则，支持 <code>id=</code>、<code>class=</code>、<code>name=</code>、<code>css=</code>、<code>xpath=</code> 等写法，按顺序优先匹配。</div>
-        </div>
-        <div class="mb-0">
-          <label class="form-label">正文元素描述</label>
-          <textarea class="form-control" name="content_selectors" rows="4" placeholder="例如：css=article .content 或 xpath=//div[@id='detail']">{{ website.content_selector_config if website and website.content_selector_config else '' }}</textarea>
-          <div class="form-text">若能匹配到对应元素，将直接使用其文本作为页面标题或正文；未匹配到时将自动回退到智能摘要，并忽略菜单及页脚文字。</div>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <button class="btn btn-primary" type="submit">保存</button>
   <a class="btn btn-secondary" href="{{ url_for('list_websites') }}">返回</a>
 </form>
@@ -96,9 +96,16 @@
     var detailSelectors = document.getElementById('detailSelectors');
     var isJsonApiCheckbox = document.getElementById('isJsonApi');
     var jsonApiConfig = document.getElementById('jsonApiConfig');
+    var listConfig = document.getElementById('listConfig');
+    var detailConfig = document.getElementById('detailConfig');
 
     function toggleDetailSelectors() {
-      if (fetchSubpagesCheckbox.checked || isJsonApiCheckbox.checked) {
+      if (isJsonApiCheckbox.checked) {
+        detailSelectors.classList.add('d-none');
+        return;
+      }
+
+      if (fetchSubpagesCheckbox.checked) {
         detailSelectors.classList.remove('d-none');
       } else {
         detailSelectors.classList.add('d-none');
@@ -108,8 +115,12 @@
     function toggleJsonApiConfig() {
       if (isJsonApiCheckbox.checked) {
         jsonApiConfig.classList.remove('d-none');
+        listConfig.classList.add('d-none');
+        detailConfig.classList.add('d-none');
       } else {
         jsonApiConfig.classList.add('d-none');
+        listConfig.classList.remove('d-none');
+        detailConfig.classList.remove('d-none');
       }
       toggleDetailSelectors();
     }


### PR DESCRIPTION
## Summary
- ensure JSON API requests advertise JSON-friendly headers to avoid HTML fallbacks
- hide list/detail configuration cards when JSON API mode is enabled and reorder sections for clarity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dfc6a709fc8320b6a5564e5b54412b