### PR TITLE
Add ability to cancel running monitor tasks

### DIFF
--- a/templates/results/list.html
+++ b/templates/results/list.html
@@ -4,7 +4,8 @@
   'running': ('warning', '执行中'),
   'success': ('success', '成功'),
   'completed': ('primary', '已完成'),
-  'failed': ('danger', '失败')
+  'failed': ('danger', '失败'),
+  'cancelled': ('secondary', '已终止')
 } %}
 <h2>监控记录</h2>
 <form class="row g-3 mb-4" method="get">

--- a/templates/tasks/detail.html
+++ b/templates/tasks/detail.html
@@ -4,7 +4,8 @@
   'running': ('warning', '执行中'),
   'success': ('success', '成功'),
   'completed': ('primary', '已完成'),
-  'failed': ('danger', '失败')
+  'failed': ('danger', '失败'),
+  'cancelled': ('secondary', '已终止')
 } %}
 
 <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
@@ -13,6 +14,11 @@
     <form method="post" action="{{ url_for('run_task_now', task_id=task.id) }}">
       <button type="submit" class="btn btn-primary" {% if active_log %}disabled{% endif %}>立即执行任务</button>
     </form>
+    {% if active_log %}
+    <form method="post" action="{{ url_for('stop_task_execution', task_id=task.id) }}">
+      <button type="submit" class="btn btn-outline-danger">停止执行</button>
+    </form>
+    {% endif %}
     <a class="btn btn-secondary" href="{{ url_for('list_tasks') }}">返回任务列表</a>
   </div>
 </div>
@@ -194,7 +200,8 @@
       running: {cls: 'warning', text: '执行中'},
       success: {cls: 'success', text: '成功'},
       completed: {cls: 'primary', text: '已完成'},
-      failed: {cls: 'danger', text: '失败'}
+      failed: {cls: 'danger', text: '失败'},
+      cancelled: {cls: 'secondary', text: '已终止'}
     };
 
     let lastEntryId = 0;

--- a/tests/test_task_cancellation.py
+++ b/tests/test_task_cancellation.py
@@ -1,0 +1,42 @@
+import threading
+import unittest
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import crawler  # noqa: E402
+
+
+class TaskCancellationHelpersTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.task_id = 12345
+        with crawler._RUNNING_TASKS_LOCK:  # type: ignore[attr-defined]
+            crawler._RUNNING_TASKS.pop(self.task_id, None)  # type: ignore[attr-defined]
+
+    def tearDown(self) -> None:
+        with crawler._RUNNING_TASKS_LOCK:  # type: ignore[attr-defined]
+            crawler._RUNNING_TASKS.pop(self.task_id, None)  # type: ignore[attr-defined]
+
+    def test_request_stop_returns_false_when_not_running(self) -> None:
+        self.assertFalse(crawler.request_stop_task(self.task_id))
+
+    def test_request_stop_sets_event(self) -> None:
+        event = threading.Event()
+        with crawler._RUNNING_TASKS_LOCK:  # type: ignore[attr-defined]
+            crawler._RUNNING_TASKS[self.task_id] = event  # type: ignore[attr-defined]
+        self.assertTrue(crawler.request_stop_task(self.task_id))
+        self.assertTrue(event.is_set())
+
+    def test_is_task_running_reflects_registry(self) -> None:
+        self.assertFalse(crawler.is_task_running(self.task_id))
+        event = threading.Event()
+        with crawler._RUNNING_TASKS_LOCK:  # type: ignore[attr-defined]
+            crawler._RUNNING_TASKS[self.task_id] = event  # type: ignore[attr-defined]
+        self.assertTrue(crawler.is_task_running(self.task_id))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a cancellation registry and stop handling to the crawler so running tasks can exit gracefully
- expose a stop endpoint and UI button so users can request cancellation from the task detail page and display the cancelled status in listings
- cover the new helpers with unit tests and document the cancelled state throughout the app

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dfd438fcf4832083b0eea7cbc1f572