### PR TITLE
Add database-backed proxy management UI

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -7,7 +7,7 @@ from collections import Counter, OrderedDict
 from datetime import datetime
 from html import escape as html_escape
 from typing import Any, Callable, Iterable, List, Sequence
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import requests
 from bs4 import BeautifulSoup
@@ -32,6 +32,8 @@ from models import (
 )
 
 from nlp import similarity
+from proxy_service import proxy_manager
+from request_profiles import get_profile_headers
 
 SIMILARITY_THRESHOLD = 0.6
 LOGGER = logging.getLogger(__name__)
@@ -278,17 +280,32 @@ def _build_browser_like_headers(url: str) -> dict[str, str]:
 
 
 def _fetch_html_with_requests(url: str, *, overrides: dict[str, str] | None = None) -> str:
+    profile_headers = get_profile_headers(url)
     headers_sequence = []
     for base_headers in (DEFAULT_REQUEST_HEADERS, _build_browser_like_headers(url)):
         headers = base_headers.copy()
+        headers.update(profile_headers)
         if overrides:
             headers.update(overrides)
         headers_sequence.append(headers)
+
+    origin = None
+    ajax_retry_added = False
     response: requests.Response | None = None
 
-    for attempt, headers in enumerate(headers_sequence, start=1):
-        response = requests.get(url, timeout=20, headers=headers)
+    attempt = 0
+    while attempt < len(headers_sequence):
+        headers = headers_sequence[attempt]
+        attempt += 1
+        proxies = proxy_manager.get_next_proxy()
+        if proxies:
+            LOGGER.debug(
+                "使用代理请求 %s，代理类型: %s",
+                url,
+                ",".join(sorted(proxies.keys())),
+            )
         try:
+            response = requests.get(url, timeout=20, headers=headers, proxies=proxies)
             response.raise_for_status()
             break
         except requests.HTTPError as exc:
@@ -296,10 +313,33 @@ def _fetch_html_with_requests(url: str, *, overrides: dict[str, str] | None = No
             if status == 403 and attempt < len(headers_sequence):
                 LOGGER.info("请求 %s 返回 403，尝试使用更接近浏览器的请求头重试", url)
                 continue
+            if (
+                status == 418
+                and overrides
+                and "X-Requested-With" in overrides
+                and not ajax_retry_added
+            ):
+                if origin is None:
+                    parsed = urlsplit(url)
+                    origin = f"{parsed.scheme}://{parsed.netloc}"
+                ajax_headers = headers.copy()
+                ajax_headers.setdefault("Origin", origin)
+                ajax_headers.setdefault("Referer", f"{origin}/")
+                headers_sequence.insert(attempt, ajax_headers)
+                ajax_retry_added = True
+                LOGGER.info("请求 %s 返回 418，尝试补充 AJAX 相关请求头后重试", url)
+                continue
             message = f"请求 {url} 失败，状态码 {status}"
             if status == 403:
                 message += "，可能需要浏览器访问或额外的身份验证"
+            if status == 418:
+                message += "，可能被目标站点的反爬虫策略拦截"
             raise CrawlError(message) from exc
+        except requests.RequestException as exc:
+            LOGGER.warning("请求 %s 出现网络错误: %s", url, exc)
+            if attempt < len(headers_sequence):
+                continue
+            raise CrawlError(f"请求 {url} 失败：{exc}") from exc
     else:  # pragma: no cover - 保底分支
         raise CrawlError(f"无法成功请求 {url}")
 

--- a/database.py
+++ b/database.py
@@ -68,3 +68,41 @@ def init_db() -> None:
             connection.exec_driver_sql(
                 "ALTER TABLE notification_logs ADD COLUMN payload TEXT"
             )
+
+    from models import ProxyEndpoint
+
+    session = SessionLocal()
+    try:
+        if session.query(ProxyEndpoint).count() == 0:
+            defaults = [
+                {
+                    "name": "本地示例代理",
+                    "http_url": "http://127.0.0.1:7890",
+                    "https_url": "http://127.0.0.1:7890",
+                },
+                {
+                    "name": "备用代理 A",
+                    "http_url": "http://192.0.2.10:8080",
+                    "https_url": "http://192.0.2.10:8080",
+                },
+                {
+                    "name": "备用代理 B",
+                    "http_url": "http://198.51.100.23:3128",
+                    "https_url": "http://198.51.100.23:3128",
+                },
+                {
+                    "name": "备用代理 C",
+                    "http_url": "http://203.0.113.45:8000",
+                    "https_url": "http://203.0.113.45:8000",
+                },
+                {
+                    "name": "备用代理 D",
+                    "http_url": "http://203.0.113.99:9000",
+                    "https_url": "http://203.0.113.99:9000",
+                },
+            ]
+            for item in defaults:
+                session.add(ProxyEndpoint(**item))
+            session.commit()
+    finally:
+        session.close()

--- a/models.py
+++ b/models.py
@@ -204,3 +204,31 @@ class NotificationLog(Base):
 
     task: Mapped[MonitorTask | None] = relationship("MonitorTask", back_populates="notification_logs")
 
+
+class ProxyEndpoint(Base):
+    __tablename__ = "proxy_endpoints"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
+    http_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    https_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    socks5_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    ftp_url: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    def to_requests_mapping(self) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        if self.http_url:
+            mapping["http"] = self.http_url
+        if self.https_url:
+            mapping["https"] = self.https_url
+        if self.socks5_url:
+            mapping["socks5"] = self.socks5_url
+        if self.ftp_url:
+            mapping["ftp"] = self.ftp_url
+        return mapping
+

--- a/proxy_service.py
+++ b/proxy_service.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+import random
+import threading
+
+from sqlalchemy import inspect, select
+from sqlalchemy.exc import SQLAlchemyError
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = ["ProxyConfigService", "proxy_manager"]
+
+from database import SessionLocal, engine
+from models import ProxyEndpoint
+
+
+class ProxyConfigService:
+    """Proxy configuration service that supports round-robin rotation."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._proxies: list[dict[str, str]] = []
+        self._index = 0
+        self.reload()
+
+    def reload(self) -> None:
+        """Reload proxy information from the database."""
+
+        proxies: list[dict[str, str]] = []
+
+        try:
+            inspector = inspect(engine)
+            if not inspector.has_table(ProxyEndpoint.__tablename__):
+                LOGGER.debug("代理配置表尚未创建，暂不加载代理配置")
+            else:
+                session = SessionLocal()
+                try:
+                    entries = (
+                        session.execute(
+                            select(ProxyEndpoint)
+                            .where(ProxyEndpoint.is_active.is_(True))
+                            .order_by(ProxyEndpoint.created_at)
+                        )
+                        .scalars()
+                        .all()
+                    )
+                    for entry in entries:
+                        mapping = entry.to_requests_mapping()
+                        if mapping:
+                            proxies.append(mapping)
+                finally:
+                    session.close()
+        except SQLAlchemyError as exc:
+            LOGGER.warning("加载代理配置失败: %s", exc)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            LOGGER.warning("加载代理配置时出现未知错误: %s", exc)
+
+        random.shuffle(proxies)
+        with self._lock:
+            self._proxies = proxies
+            self._index = 0
+
+    def get_next_proxy(self) -> dict[str, str] | None:
+        """Return the next proxy configuration, or ``None`` if unavailable."""
+
+        with self._lock:
+            if not self._proxies:
+                return None
+            proxy = self._proxies[self._index].copy()
+            self._index = (self._index + 1) % len(self._proxies)
+            return proxy
+
+    def has_proxies(self) -> bool:
+        with self._lock:
+            return bool(self._proxies)
+
+
+proxy_manager = ProxyConfigService()
+

--- a/request_profiles.py
+++ b/request_profiles.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable
+from urllib.parse import urlsplit
+
+__all__ = ["get_profile_headers", "RequestProfile"]
+
+
+@dataclass(frozen=True)
+class RequestProfile:
+    """Lightweight representation of a rotating request header profile."""
+
+    user_agent: str
+    referer_template: str
+    accept_language: str
+    accept: str
+
+    def build_headers(self, url: str) -> dict[str, str]:
+        parts = urlsplit(url)
+        mapping = {
+            "scheme": parts.scheme,
+            "netloc": parts.netloc,
+            "hostname": parts.hostname or parts.netloc,
+            "url": url,
+            "path": parts.path or "/",
+        }
+        referer = self.referer_template.format(**mapping)
+        headers: dict[str, str] = {
+            "User-Agent": self.user_agent,
+            "Accept-Language": self.accept_language,
+            "Accept": self.accept,
+        }
+        if referer:
+            headers["Referer"] = referer
+        return headers
+
+
+def _desktop_chrome(version: int, windows_version: str) -> str:
+    return (
+        "Mozilla/5.0 (Windows NT "
+        f"{windows_version}; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{version}.0.0.0 Safari/537.36"
+    )
+
+
+def _mac_chrome(version: int, os_version: str) -> str:
+    return (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X "
+        f"{os_version}) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{version}.0.0.0 Safari/537.36"
+    )
+
+
+def _firefox(version: int, platform: str) -> str:
+    return (
+        f"Mozilla/5.0 ({platform}; rv:{version}.0) Gecko/20100101 Firefox/{version}.0"
+    )
+
+
+def _edge(version: int, windows_version: str) -> str:
+    return (
+        "Mozilla/5.0 (Windows NT "
+        f"{windows_version}; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{version}.0.0.0 Safari/537.36 Edg/{version}.0.0.0"
+    )
+
+
+def _safari(version: int, os_version: str) -> str:
+    return (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X "
+        f"{os_version}) AppleWebKit/605.1.15 (KHTML, like Gecko) "
+        f"Version/{version}.0 Safari/605.1.15"
+    )
+
+
+def _ios_safari(version: int, device: str, os_version: str) -> str:
+    return (
+        "Mozilla/5.0 (" + device + f"; CPU iPhone OS {os_version} like Mac OS X) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) "
+        f"Version/{version}.0 Mobile/15E148 Safari/604.1"
+    )
+
+
+def _android_chrome(version: int, android_version: str, device: str) -> str:
+    return (
+        "Mozilla/5.0 (Linux; Android "
+        f"{android_version}; {device}) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{version}.0.0.0 Mobile Safari/537.36"
+    )
+
+
+_WINDOWS_VERSIONS = ["10.0", "11.0", "6.3", "6.1"]
+_MAC_OS_VERSIONS = [
+    "10_15_7",
+    "11_6_8",
+    "12_6_7",
+    "13_5_2",
+    "14_0",
+]
+_FIREFOX_PLATFORMS = [
+    "Windows NT 10.0; Win64; x64",
+    "Windows NT 6.1; Win64; x64",
+    "Macintosh; Intel Mac OS X 10.15",
+    "X11; Ubuntu; Linux x86_64",
+]
+_EDGE_WINDOWS_VERSIONS = ["10.0", "11.0"]
+_IOS_DEVICES = [
+    "iPhone",
+    "iPhone; CPU iPhone OS",
+    "iPad",
+]
+_IOS_OS_VERSIONS = ["14_7", "15_6", "16_5", "17_3"]
+_ANDROID_VERSIONS = ["10", "11", "12", "13", "14"]
+_ANDROID_DEVICES = [
+    "Pixel 5",
+    "Pixel 7",
+    "Mi 11",
+    "Mate 40",
+    "SM-G998B",
+    "OnePlus 9",
+    "PCLM10",
+]
+
+_REFERER_TEMPLATES = [
+    "{scheme}://{netloc}/",
+    "{scheme}://{netloc}{path}",
+    "https://www.google.com/search?q={netloc}",
+    "https://www.google.com.hk/search?q={netloc}",
+    "https://www.baidu.com/s?wd={netloc}",
+    "https://cn.bing.com/search?q={netloc}",
+    "https://search.yahoo.com/search?p={netloc}",
+    "https://duckduckgo.com/?q={netloc}",
+    "https://www.sogou.com/web?query={netloc}",
+    "https://m.baidu.com/s?wd={netloc}",
+    "https://www.sm.cn/s?q={netloc}",
+    "https://m.sm.cn/s?q={netloc}",
+    "https://so.com/s?q={netloc}",
+    "https://www.ecosia.org/search?q={netloc}",
+    "https://yandex.com/search/?text={netloc}",
+    "https://www.zhihu.com/search?type=content&q={netloc}",
+    "https://weixin.sogou.com/weixin?type=2&query={netloc}",
+    "https://www.qwant.com/?q={netloc}",
+    "https://www.bilibili.com/search?keyword={netloc}",
+    "https://m.sogou.com/web/searchList.jsp?keyword={netloc}",
+]
+
+_ACCEPT_LANGUAGES = [
+    "zh-CN,zh;q=0.9,en;q=0.7",
+    "zh-CN,zh;q=0.8,en-US;q=0.6",
+    "en-US,en;q=0.9,zh-CN;q=0.6",
+    "zh-TW,zh;q=0.8,en;q=0.5",
+    "en-GB,en;q=0.9,zh-CN;q=0.4",
+    "ja-JP,ja;q=0.9,en-US;q=0.6",
+    "ko-KR,ko;q=0.9,en-US;q=0.6",
+    "de-DE,de;q=0.9,en-US;q=0.6",
+    "fr-FR,fr;q=0.9,en;q=0.6",
+    "es-ES,es;q=0.9,en;q=0.5",
+]
+
+_ACCEPT_HEADERS = [
+    "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+    "text/html,application/json;q=0.9,*/*;q=0.8",
+    "text/html,application/xhtml+xml;q=0.9,*/*;q=0.7",
+    "text/html,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+]
+
+
+def _iter_user_agents() -> Iterable[str]:
+    for idx, version in enumerate(range(114, 144)):
+        windows_version = _WINDOWS_VERSIONS[idx % len(_WINDOWS_VERSIONS)]
+        yield _desktop_chrome(version, windows_version)
+    for idx, version in enumerate(range(96, 116)):
+        os_version = _MAC_OS_VERSIONS[idx % len(_MAC_OS_VERSIONS)]
+        yield _mac_chrome(version, os_version)
+    for idx, version in enumerate(range(88, 108)):
+        platform = _FIREFOX_PLATFORMS[idx % len(_FIREFOX_PLATFORMS)]
+        yield _firefox(version, platform)
+    for idx, version in enumerate(range(100, 118)):
+        windows_version = _EDGE_WINDOWS_VERSIONS[idx % len(_EDGE_WINDOWS_VERSIONS)]
+        yield _edge(version, windows_version)
+    for idx, version in enumerate(range(14, 30)):
+        os_version = _MAC_OS_VERSIONS[idx % len(_MAC_OS_VERSIONS)]
+        yield _safari(version, os_version)
+    for idx, version in enumerate(range(14, 26)):
+        device = _IOS_DEVICES[idx % len(_IOS_DEVICES)]
+        os_version = _IOS_OS_VERSIONS[idx % len(_IOS_OS_VERSIONS)]
+        yield _ios_safari(version, device, os_version)
+    for idx, version in enumerate(range(96, 122)):
+        android_version = _ANDROID_VERSIONS[idx % len(_ANDROID_VERSIONS)]
+        device = _ANDROID_DEVICES[idx % len(_ANDROID_DEVICES)]
+        yield _android_chrome(version, android_version, device)
+
+
+def _build_profiles() -> list[RequestProfile]:
+    profiles: list[RequestProfile] = []
+    for idx, user_agent in enumerate(_iter_user_agents()):
+        referer_template = _REFERER_TEMPLATES[idx % len(_REFERER_TEMPLATES)]
+        accept_language = _ACCEPT_LANGUAGES[idx % len(_ACCEPT_LANGUAGES)]
+        accept = _ACCEPT_HEADERS[idx % len(_ACCEPT_HEADERS)]
+        profiles.append(
+            RequestProfile(
+                user_agent=user_agent,
+                referer_template=referer_template,
+                accept_language=accept_language,
+                accept=accept,
+            )
+        )
+        if len(profiles) >= 100:
+            break
+    return profiles
+
+
+_REQUEST_PROFILES: list[RequestProfile] = _build_profiles()
+if len(_REQUEST_PROFILES) < 100:  # pragma: no cover - configuration guard
+    raise RuntimeError("未能生成足够的请求配置，至少需要 100 个")
+_RANDOM = random.SystemRandom()
+
+
+def get_profile_headers(url: str) -> dict[str, str]:
+    """Return a randomized set of headers tailored for the given URL."""
+
+    profile = _RANDOM.choice(_REQUEST_PROFILES)
+    return profile.build_headers(url)
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,7 @@
           <a class="nav-link" href="{{ url_for('list_tasks') }}">监控任务</a>
           <a class="nav-link" href="{{ url_for('list_results') }}">监控记录</a>
           <a class="nav-link" href="{{ url_for('manage_notifications') }}">通知配置</a>
+          <a class="nav-link" href="{{ url_for('list_proxy_endpoints') }}">系统管理</a>
         </div>
       </div>
     </nav>

--- a/templates/system/proxies/form.html
+++ b/templates/system/proxies/form.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-6">
+    <h2 class="mb-3">{{ '编辑代理配置' if proxy else '新增代理配置' }}</h2>
+    <form method="post" class="card">
+      <div class="card-body d-grid gap-3">
+        <div>
+          <label class="form-label">名称</label>
+          <input type="text" name="name" class="form-control" value="{{ proxy.name if proxy else '' }}" required>
+        </div>
+        <div>
+          <label class="form-label">HTTP 代理</label>
+          <input type="text" name="http_url" class="form-control" placeholder="例如：http://127.0.0.1:7890" value="{{ proxy.http_url if proxy else '' }}">
+        </div>
+        <div>
+          <label class="form-label">HTTPS 代理</label>
+          <input type="text" name="https_url" class="form-control" placeholder="例如：http://127.0.0.1:7890" value="{{ proxy.https_url if proxy else '' }}">
+        </div>
+        <div>
+          <label class="form-label">SOCKS5 代理</label>
+          <input type="text" name="socks5_url" class="form-control" placeholder="例如：socks5://127.0.0.1:1080" value="{{ proxy.socks5_url if proxy else '' }}">
+        </div>
+        <div>
+          <label class="form-label">FTP 代理</label>
+          <input type="text" name="ftp_url" class="form-control" value="{{ proxy.ftp_url if proxy else '' }}">
+          <div class="form-text">至少填写一个可用的代理地址。</div>
+        </div>
+        <div class="form-check form-switch">
+          <input class="form-check-input" type="checkbox" id="proxyActive" name="is_active" {% if proxy is none or proxy.is_active %}checked{% endif %}>
+          <label class="form-check-label" for="proxyActive">启用该代理</label>
+        </div>
+      </div>
+      <div class="card-footer d-flex justify-content-between">
+        <a href="{{ url_for('list_proxy_endpoints') }}" class="btn btn-outline-secondary">返回列表</a>
+        <button type="submit" class="btn btn-primary">保存</button>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/templates/system/proxies/list.html
+++ b/templates/system/proxies/list.html
@@ -1,0 +1,74 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <div>
+    <h2 class="mb-0">代理配置管理</h2>
+    <p class="text-muted small mb-0">当前共有 {{ total_count }} 条配置，启用 {{ active_count }} 条。</p>
+  </div>
+  <a href="{{ url_for('create_proxy_endpoint') }}" class="btn btn-primary">新增代理</a>
+</div>
+<div class="card">
+  <div class="card-header">代理列表</div>
+  <div class="table-responsive">
+    <table class="table table-striped table-hover mb-0 align-middle">
+      <thead>
+        <tr>
+          <th style="width: 20%;">名称</th>
+          <th style="width: 30%;">HTTP</th>
+          <th style="width: 30%;">HTTPS</th>
+          <th>其他协议</th>
+          <th class="text-center" style="width: 10%;">状态</th>
+          <th class="text-center" style="width: 16%;">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for proxy in proxies %}
+        <tr>
+          <td class="fw-semibold">{{ proxy.name }}</td>
+          <td class="text-break">{{ proxy.http_url or '—' }}</td>
+          <td class="text-break">{{ proxy.https_url or '—' }}</td>
+          <td class="text-break">
+            {% set extra = [] %}
+            {% if proxy.socks5_url %}
+            {% set _ = extra.append('SOCKS5: ' ~ proxy.socks5_url) %}
+            {% endif %}
+            {% if proxy.ftp_url %}
+            {% set _ = extra.append('FTP: ' ~ proxy.ftp_url) %}
+            {% endif %}
+            {% if extra %}
+            {{ extra | join('<br>') | safe }}
+            {% else %}
+            —
+            {% endif %}
+          </td>
+          <td class="text-center">
+            {% if proxy.is_active %}
+            <span class="badge text-bg-success">启用</span>
+            {% else %}
+            <span class="badge text-bg-secondary">停用</span>
+            {% endif %}
+          </td>
+          <td>
+            <div class="d-flex justify-content-center gap-2">
+              <a href="{{ url_for('edit_proxy_endpoint', proxy_id=proxy.id) }}" class="btn btn-sm btn-outline-secondary">编辑</a>
+              <form method="post" action="{{ url_for('toggle_proxy_endpoint', proxy_id=proxy.id) }}">
+                <button type="submit" class="btn btn-sm {% if proxy.is_active %}btn-outline-warning{% else %}btn-outline-success{% endif %}">
+                  {% if proxy.is_active %}停用{% else %}启用{% endif %}
+                </button>
+              </form>
+              <form method="post" action="{{ url_for('delete_proxy_endpoint', proxy_id=proxy.id) }}" onsubmit="return confirm('确认删除该代理配置？');">
+                <button type="submit" class="btn btn-sm btn-outline-danger">删除</button>
+              </form>
+            </div>
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="6" class="text-center text-muted py-4">暂无代理配置，请先新增。</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_content_categories.py
+++ b/tests/test_content_categories.py
@@ -9,6 +9,7 @@ from models import ContentCategory, WatchContent
 class ContentCategoryRoutesTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.db_path = Path("data.db")
+        engine.dispose()
         if self.db_path.exists():
             self.db_path.unlink()
         Base.metadata.create_all(bind=engine)
@@ -19,6 +20,7 @@ class ContentCategoryRoutesTestCase(unittest.TestCase):
 
     def tearDown(self) -> None:
         SessionLocal.remove()
+        engine.dispose()
         Base.metadata.drop_all(bind=engine)
         if self.db_path.exists():
             self.db_path.unlink()

--- a/tests/test_proxy_management.py
+++ b/tests/test_proxy_management.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from database import SessionLocal, engine, init_db
+from models import ProxyEndpoint
+from proxy_service import ProxyConfigService
+
+
+def setup_function(function):
+    engine.dispose()
+    db_path = Path("data.db")
+    if db_path.exists():
+        db_path.unlink()
+    init_db()
+
+
+def teardown_function(function):
+    SessionLocal.remove()
+    engine.dispose()
+    db_path = Path("data.db")
+    if db_path.exists():
+        db_path.unlink()
+
+
+def test_default_proxy_seed_data_present():
+    session = SessionLocal()
+    try:
+        proxies = session.query(ProxyEndpoint).all()
+        assert proxies, "Expected default proxy endpoints to be seeded"
+        assert any(proxy.is_active for proxy in proxies)
+        assert all(proxy.name for proxy in proxies)
+    finally:
+        session.close()
+
+
+def test_proxy_service_reflects_database_updates():
+    session = SessionLocal()
+    try:
+        # create a dedicated proxy for this test
+        test_proxy = ProxyEndpoint(
+            name="测试代理",
+            http_url="http://127.0.0.1:9999",
+            https_url="http://127.0.0.1:9999",
+            is_active=True,
+        )
+        session.add(test_proxy)
+        session.commit()
+
+        service = ProxyConfigService()
+        service.reload()
+
+        active_proxies = (
+            session.query(ProxyEndpoint)
+            .filter(ProxyEndpoint.is_active.is_(True))
+            .all()
+        )
+        expected = [proxy.to_requests_mapping() for proxy in active_proxies if proxy.to_requests_mapping()]
+        collected = []
+        for _ in range(len(expected)):
+            proxy_mapping = service.get_next_proxy()
+            assert proxy_mapping is not None
+            collected.append(proxy_mapping)
+
+        assert any(
+            mapping.get("http") == "http://127.0.0.1:9999" for mapping in collected
+        )
+
+        # disable the test proxy and ensure service reload reflects it
+        test_proxy.is_active = False
+        session.commit()
+        service.reload()
+        # the service should still rotate without raising errors
+        for _ in range(max(1, len(expected) - 1)):
+            service.get_next_proxy()
+    finally:
+        if "test_proxy" in locals():
+            try:
+                session.delete(test_proxy)
+                session.commit()
+            except Exception:  # noqa: BLE001
+                session.rollback()
+        session.close()


### PR DESCRIPTION
## Summary
- add a ProxyEndpoint model with default proxy seeds and refresh the scheduler setup
- replace the file-based proxy configuration with database-backed management routes, templates, and service logic
- cover the new flow with proxy management tests and dispose database engines in existing category tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd4d8abb083208f02aa7d445d15bc