### PR TITLE
Add immersive monitoring cockpit dashboard

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,10 +12,11 @@
         <div class="navbar-nav">
           <a class="nav-link" href="{{ url_for('list_websites') }}">关注网站</a>
           <a class="nav-link" href="{{ url_for('list_contents') }}">关注内容</a>
-          <a class="nav-link" href="{{ url_for('list_tasks') }}">监控任务</a>
-          <a class="nav-link" href="{{ url_for('list_results') }}">监控记录</a>
-          <a class="nav-link" href="{{ url_for('manage_notifications') }}">通知配置</a>
-          <a class="nav-link" href="{{ url_for('list_proxy_endpoints') }}">系统管理</a>
+        <a class="nav-link" href="{{ url_for('list_tasks') }}">监控任务</a>
+        <a class="nav-link" href="{{ url_for('list_results') }}">监控记录</a>
+        <a class="nav-link" href="{{ url_for('manage_notifications') }}">通知配置</a>
+        <a class="nav-link" href="{{ url_for('list_proxy_endpoints') }}">系统管理</a>
+        <a class="nav-link" href="{{ url_for('cockpit_dashboard') }}">驾驶舱</a>
         </div>
       </div>
     </nav>

--- a/templates/dashboard/cockpit.html
+++ b/templates/dashboard/cockpit.html
@@ -1,0 +1,700 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <title>政策监控驾驶舱</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+      :root {
+        --bg-dark: #020b1e;
+        --bg-panel: rgba(7, 23, 52, 0.7);
+        --bg-panel-solid: #071734;
+        --accent: #00c6ff;
+        --accent-soft: rgba(0, 198, 255, 0.35);
+        --text-main: #e6f3ff;
+        --text-dim: #6f9ac3;
+        --success: #3fe0a3;
+        --danger: #ff6b8a;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+        color: var(--text-main);
+        background: radial-gradient(circle at 20% 20%, rgba(0, 198, 255, 0.1), transparent 40%),
+                    radial-gradient(circle at 80% 0%, rgba(99, 102, 241, 0.15), transparent 55%),
+                    linear-gradient(135deg, #010409, #020b1e 70%, #031435);
+        display: flex;
+        flex-direction: column;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 24px 48px 16px;
+      }
+
+      .brand {
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: 6px;
+        text-transform: uppercase;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .brand::before {
+        content: '';
+        width: 10px;
+        height: 32px;
+        background: linear-gradient(180deg, var(--accent), transparent);
+        border-radius: 4px;
+      }
+
+      .nav-actions {
+        display: flex;
+        gap: 12px;
+      }
+
+      .nav-actions a {
+        text-decoration: none;
+        color: var(--text-main);
+        border: 1px solid rgba(0, 198, 255, 0.35);
+        padding: 10px 18px;
+        border-radius: 999px;
+        font-size: 14px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        background: rgba(0, 198, 255, 0.08);
+        box-shadow: 0 0 12px rgba(0, 198, 255, 0.15) inset;
+        transition: all 0.2s ease;
+      }
+
+      .nav-actions a:hover {
+        border-color: var(--accent);
+        color: #fff;
+        box-shadow: 0 0 18px rgba(0, 198, 255, 0.45);
+      }
+
+      main {
+        flex: 1;
+        padding: 0 48px 32px;
+        display: grid;
+        grid-template-columns: 320px minmax(0, 1fr) 320px;
+        gap: 28px;
+      }
+
+      .panel {
+        background: var(--bg-panel);
+        border: 1px solid rgba(0, 198, 255, 0.15);
+        border-radius: 18px;
+        padding: 20px 22px;
+        backdrop-filter: blur(8px);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .panel::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: linear-gradient(135deg, rgba(0, 198, 255, 0.12), transparent 55%);
+        pointer-events: none;
+      }
+
+      .panel h2 {
+        margin: 0 0 12px;
+        font-size: 18px;
+        text-transform: uppercase;
+        letter-spacing: 2px;
+      }
+
+      .panel h2 span {
+        font-size: 12px;
+        color: var(--text-dim);
+        margin-left: 10px;
+      }
+
+      .websites-list {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-height: calc(100vh - 220px);
+        overflow: auto;
+        padding-right: 4px;
+      }
+
+      .website-item {
+        background: var(--bg-panel-solid);
+        border-radius: 14px;
+        padding: 14px 16px;
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+      }
+
+      .website-item strong {
+        font-size: 16px;
+      }
+
+      .website-item .meta {
+        font-size: 12px;
+        color: var(--text-dim);
+      }
+
+      .website-item .count {
+        font-size: 20px;
+        font-weight: 600;
+        color: var(--accent);
+        text-align: right;
+      }
+
+      .website-item .progress {
+        grid-column: span 2;
+        height: 6px;
+        border-radius: 999px;
+        background: rgba(0, 198, 255, 0.1);
+        overflow: hidden;
+      }
+
+      .website-item .progress span {
+        display: block;
+        height: 100%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, rgba(0, 198, 255, 0.2), var(--accent));
+        transform-origin: left;
+      }
+
+      .keywords-panel ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .keywords-panel li {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px 12px;
+        background: rgba(0, 198, 255, 0.05);
+        border: 1px solid rgba(0, 198, 255, 0.1);
+        border-radius: 10px;
+      }
+
+      .keywords-panel li span:last-child {
+        font-weight: 600;
+        color: var(--accent);
+      }
+
+      .center-cluster {
+        display: grid;
+        grid-template-rows: minmax(0, 3fr) 160px;
+        gap: 20px;
+      }
+
+      .puzzle-wrapper {
+        position: relative;
+        background: rgba(1, 14, 36, 0.85);
+        border-radius: 18px;
+        border: 1px solid rgba(0, 198, 255, 0.2);
+        padding: 24px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .puzzle-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+      }
+
+      .puzzle-header h2 {
+        margin: 0;
+        font-size: 18px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+      }
+
+      .puzzle-grid {
+        flex: 1;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        grid-auto-rows: 90px;
+        gap: 14px;
+        perspective: 800px;
+      }
+
+      .puzzle-piece {
+        position: relative;
+        border-radius: 18px;
+        background: linear-gradient(145deg, rgba(0, 198, 255, 0.2), rgba(2, 11, 30, 0.6));
+        border: 1px solid rgba(0, 198, 255, 0.25);
+        box-shadow: 0 20px 35px rgba(0, 0, 0, 0.45);
+        padding: 16px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        transform: rotateX(6deg);
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+      }
+
+      .puzzle-piece:hover {
+        transform: rotateX(0deg) translateY(-4px);
+        box-shadow: 0 26px 45px rgba(0, 0, 0, 0.55);
+      }
+
+      .puzzle-piece strong {
+        font-size: 18px;
+      }
+
+      .puzzle-piece span {
+        font-size: 12px;
+        color: var(--text-dim);
+      }
+
+      .logs-panel {
+        background: rgba(0, 0, 0, 0.35);
+        border-radius: 16px;
+        border: 1px solid rgba(0, 198, 255, 0.2);
+        padding: 16px 18px;
+        font-family: 'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        overflow: hidden;
+      }
+
+      .logs-panel h3 {
+        margin: 0 0 8px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        font-size: 16px;
+      }
+
+      .logs-stream {
+        height: 100%;
+        overflow: hidden;
+        position: relative;
+      }
+
+      .logs-stream ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column-reverse;
+        gap: 6px;
+        animation: scrollLogs 15s linear infinite;
+      }
+
+      @keyframes scrollLogs {
+        from {
+          transform: translateY(0%);
+        }
+        to {
+          transform: translateY(-50%);
+        }
+      }
+
+      .logs-stream li {
+        display: flex;
+        gap: 12px;
+        color: var(--text-dim);
+        font-size: 13px;
+        white-space: nowrap;
+      }
+
+      .logs-stream li .time {
+        color: var(--accent);
+      }
+
+      .logs-stream li .level-info {
+        color: var(--text-dim);
+      }
+
+      .logs-stream li .level-error {
+        color: var(--danger);
+      }
+
+      .logs-stream li .level-success {
+        color: var(--success);
+      }
+
+      .sidebar {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .tasks-panel ul,
+      .notifications-panel ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        max-height: 240px;
+        overflow-y: auto;
+      }
+
+      .tasks-panel li,
+      .notifications-panel li {
+        background: rgba(0, 198, 255, 0.06);
+        border: 1px solid rgba(0, 198, 255, 0.12);
+        border-radius: 12px;
+        padding: 12px 14px;
+        font-size: 13px;
+      }
+
+      .notifications-panel li strong {
+        display: block;
+        color: var(--accent);
+      }
+
+      .timestamp {
+        color: var(--text-dim);
+        font-size: 12px;
+      }
+
+      footer {
+        padding: 12px 48px 24px;
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        color: var(--text-dim);
+      }
+
+      .glow-ring {
+        position: absolute;
+        width: 140px;
+        height: 140px;
+        border-radius: 50%;
+        border: 1px solid rgba(0, 198, 255, 0.35);
+        filter: blur(0.6px);
+        animation: pulse 8s ease-in-out infinite;
+      }
+
+      .glow-ring:nth-child(1) {
+        top: -40px;
+        right: -60px;
+      }
+
+      .glow-ring:nth-child(2) {
+        bottom: -50px;
+        left: -70px;
+        animation-delay: 2s;
+      }
+
+      @keyframes pulse {
+        0%, 100% {
+          transform: scale(0.85);
+          opacity: 0.25;
+        }
+        50% {
+          transform: scale(1.1);
+          opacity: 0.5;
+        }
+      }
+
+      @media (max-width: 1600px) {
+        main {
+          grid-template-columns: 280px minmax(0, 1fr) 280px;
+          padding: 0 24px 24px;
+        }
+        header,
+        footer {
+          padding-left: 24px;
+          padding-right: 24px;
+        }
+      }
+
+      @media (max-width: 1280px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+        .sidebar {
+          order: -1;
+          flex-direction: row;
+          flex-wrap: wrap;
+        }
+        .sidebar .panel {
+          flex: 1 1 45%;
+        }
+        .websites-list {
+          max-height: 360px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="brand">POLICY MATRIX</div>
+      <div class="nav-actions">
+        <a href="{{ url_for('list_tasks') }}">监控任务</a>
+        <a href="{{ url_for('list_websites') }}">关注网站</a>
+        <a href="{{ url_for('list_results') }}">监控记录</a>
+        <a href="{{ url_for('manage_notifications') }}">通知配置</a>
+      </div>
+    </header>
+    <main>
+      <section class="panel">
+        <h2>关注网站<span id="overview-updated">--</span></h2>
+        <div class="websites-list" id="websites-list"></div>
+      </section>
+      <section class="center-cluster">
+        <div class="puzzle-wrapper">
+          <div class="glow-ring"></div>
+          <div class="glow-ring"></div>
+          <div class="puzzle-header">
+            <h2>流量拼图</h2>
+            <div class="timestamp" id="puzzle-timestamp">--</div>
+          </div>
+          <div class="puzzle-grid" id="puzzle-grid"></div>
+        </div>
+        <div class="logs-panel">
+          <h3>实时日志</h3>
+          <div class="logs-stream">
+            <ul id="logs-list"></ul>
+          </div>
+        </div>
+      </section>
+      <aside class="sidebar">
+        <section class="panel keywords-panel">
+          <h2>热度排行</h2>
+          <ul id="keyword-sites"></ul>
+        </section>
+        <section class="panel tasks-panel">
+          <h2>执行中任务</h2>
+          <ul id="running-tasks"></ul>
+        </section>
+        <section class="panel notifications-panel">
+          <h2>通知动态</h2>
+          <ul id="notifications"></ul>
+        </section>
+      </aside>
+    </main>
+    <footer>
+      <span>政策监控驾驶舱</span>
+      <span id="current-time"></span>
+    </footer>
+
+    <script>
+      const formatter = new Intl.NumberFormat('zh-CN');
+
+      function updateClock() {
+        const now = new Date();
+        const formatted = now.toLocaleString('zh-CN', {
+          hour12: false,
+          year: 'numeric',
+          month: '2-digit',
+          day: '2-digit',
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit'
+        });
+        document.getElementById('current-time').textContent = formatted;
+      }
+
+      setInterval(updateClock, 1000);
+      updateClock();
+
+      async function fetchJSON(url) {
+        const response = await fetch(url, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error('请求失败');
+        }
+        return response.json();
+      }
+
+      function renderWebsites(data) {
+        const list = document.getElementById('websites-list');
+        list.innerHTML = '';
+        const maxCount = Math.max(...data.map(item => item.result_count || 0), 1);
+        if (!data.length) {
+          const empty = document.createElement('div');
+          empty.className = 'website-item';
+          empty.innerHTML = '<strong>暂无关注网站</strong><div class="meta">请在后台添加监控站点</div>';
+          list.appendChild(empty);
+          return;
+        }
+        data.forEach(item => {
+          const wrapper = document.createElement('div');
+          wrapper.className = 'website-item';
+          wrapper.innerHTML = `
+            <div>
+              <strong>${item.name}</strong>
+              <div class="meta">${item.url}</div>
+            </div>
+            <div class="count">${formatter.format(item.result_count)}</div>
+            <div class="progress"><span style="width: ${(item.result_count / maxCount) * 100}%"></span></div>
+          `;
+          list.appendChild(wrapper);
+        });
+      }
+
+      function renderPuzzle(data) {
+        const grid = document.getElementById('puzzle-grid');
+        grid.innerHTML = '';
+        const maxCount = Math.max(...data.map(item => item.result_count || 0), 1);
+        if (!data.length) {
+          const placeholder = document.createElement('div');
+          placeholder.className = 'puzzle-piece';
+          placeholder.innerHTML = '<strong>等待数据</strong><span>暂无访问记录</span>';
+          grid.appendChild(placeholder);
+          return;
+        }
+        data.forEach(item => {
+          const piece = document.createElement('div');
+          const weight = item.result_count / maxCount;
+          const span = Math.max(1, Math.round(weight * 3));
+          piece.className = 'puzzle-piece';
+          piece.style.gridColumn = `span ${span}`;
+          piece.style.gridRow = `span ${span}`;
+          piece.innerHTML = `
+            <strong>${item.name}</strong>
+            <span>${formatter.format(item.result_count)} 次访问</span>
+          `;
+          grid.appendChild(piece);
+        });
+      }
+
+      function renderKeywordSites(data) {
+        const list = document.getElementById('keyword-sites');
+        list.innerHTML = '';
+        data.slice(0, 8).forEach(item => {
+          const li = document.createElement('li');
+          li.innerHTML = `<span>${item.name}</span><span>${formatter.format(item.result_count)}</span>`;
+          list.appendChild(li);
+        });
+        if (!data.length) {
+          const empty = document.createElement('li');
+          empty.textContent = '暂无数据';
+          list.appendChild(empty);
+        }
+      }
+
+      function renderTasks(items) {
+        const list = document.getElementById('running-tasks');
+        list.innerHTML = '';
+        if (!items.length) {
+          const empty = document.createElement('li');
+          empty.textContent = '当前没有正在执行的任务';
+          list.appendChild(empty);
+          return;
+        }
+        items.forEach(item => {
+          const li = document.createElement('li');
+          li.innerHTML = `
+            <div><strong>${item.task_name || '未知任务'}</strong></div>
+            <div class="timestamp">${item.website || ''}</div>
+            <div class="timestamp">启动于 ${item.started_at || '--'}</div>
+          `;
+          list.appendChild(li);
+        });
+      }
+
+      function renderNotifications(items) {
+        const list = document.getElementById('notifications');
+        list.innerHTML = '';
+        if (!items.length) {
+          const empty = document.createElement('li');
+          empty.textContent = '暂无通知';
+          list.appendChild(empty);
+          return;
+        }
+        items.forEach(item => {
+          const li = document.createElement('li');
+          li.innerHTML = `
+            <strong>${item.task_name || item.channel}</strong>
+            <div>${item.message || ''}</div>
+            <div class="timestamp">${item.created_at || '--'} · ${item.status}</div>
+          `;
+          list.appendChild(li);
+        });
+      }
+
+      function renderLogs(entries) {
+        const list = document.getElementById('logs-list');
+        list.innerHTML = '';
+        entries.forEach(entry => {
+          const li = document.createElement('li');
+          const levelClass = `level-${entry.level?.toLowerCase() || 'info'}`;
+          li.innerHTML = `
+            <span class="time">${entry.created_at || '--'}</span>
+            <span class="${levelClass}">${(entry.task_name || '系统')} ▸ ${entry.message}</span>
+          `;
+          list.appendChild(li);
+        });
+      }
+
+      async function refreshOverview() {
+        try {
+          const data = await fetchJSON('{{ url_for('cockpit_overview') }}');
+          renderWebsites(data.websites);
+          renderPuzzle(data.websites);
+          renderKeywordSites(data.keyword_hot_sites);
+          document.getElementById('overview-updated').textContent = data.updated_at || '--';
+          document.getElementById('puzzle-timestamp').textContent = `更新：${data.updated_at || '--'}`;
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function refreshTasks() {
+        try {
+          const data = await fetchJSON('{{ url_for('cockpit_tasks') }}');
+          renderTasks(data.running || []);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function refreshNotifications() {
+        try {
+          const data = await fetchJSON('{{ url_for('cockpit_notifications') }}');
+          renderNotifications(data.items || []);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      async function refreshLogs() {
+        try {
+          const data = await fetchJSON('{{ url_for('cockpit_logs') }}');
+          renderLogs(data.entries || []);
+        } catch (err) {
+          console.error(err);
+        }
+      }
+
+      refreshOverview();
+      refreshTasks();
+      refreshNotifications();
+      refreshLogs();
+
+      setInterval(refreshOverview, 20000);
+      setInterval(refreshTasks, 12000);
+      setInterval(refreshNotifications, 15000);
+      setInterval(refreshLogs, 6000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a full-screen cockpit dashboard with animated layout, navigation shortcuts, and live data panels
- expose JSON APIs for website statistics, running tasks, notification history, and streaming logs
- link the cockpit page from the main navigation for quick access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfe5b32084832095fc1c25732ae501