### PR TITLE
Adjust cockpit website and puzzle styling

### DIFF
--- a/templates/dashboard/cockpit.html
+++ b/templates/dashboard/cockpit.html
@@ -131,9 +131,10 @@
         display: flex;
         flex-direction: column;
         gap: 12px;
-        max-height: calc(100vh - 220px);
-        overflow: auto;
-        padding-right: 4px;
+        width: 100%;
+        max-height: none;
+        overflow: visible;
+        padding-right: 0;
       }
 
       .website-item {
@@ -144,15 +145,19 @@
         grid-template-columns: 1fr auto;
         gap: 8px;
         box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+        width: 100%;
       }
 
       .website-item strong {
         font-size: 16px;
+        display: block;
+        overflow-wrap: anywhere;
       }
 
       .website-item .meta {
         font-size: 12px;
         color: var(--text-dim);
+        overflow-wrap: anywhere;
       }
 
       .website-item .count {
@@ -236,8 +241,8 @@
       .puzzle-grid {
         flex: 1;
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-        grid-auto-rows: 90px;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        grid-auto-rows: 110px;
         gap: 14px;
         perspective: 800px;
       }
@@ -245,7 +250,6 @@
       .puzzle-piece {
         position: relative;
         border-radius: 18px;
-        background: linear-gradient(145deg, rgba(0, 198, 255, 0.2), rgba(2, 11, 30, 0.6));
         border: 1px solid rgba(0, 198, 255, 0.25);
         box-shadow: 0 20px 35px rgba(0, 0, 0, 0.45);
         padding: 16px;
@@ -255,6 +259,7 @@
         justify-content: space-between;
         transform: rotateX(6deg);
         transition: transform 0.3s ease, box-shadow 0.3s ease;
+        background: linear-gradient(145deg, rgba(0, 198, 255, 0.2), rgba(2, 11, 30, 0.6));
       }
 
       .puzzle-piece:hover {
@@ -264,11 +269,33 @@
 
       .puzzle-piece strong {
         font-size: 18px;
+        overflow-wrap: anywhere;
       }
 
       .puzzle-piece span {
-        font-size: 12px;
+        font-size: 16px;
         color: var(--text-dim);
+        font-weight: 600;
+      }
+
+      .puzzle-piece.color-0 {
+        background: linear-gradient(145deg, rgba(0, 198, 255, 0.28), rgba(1, 28, 58, 0.75));
+        border-color: rgba(0, 198, 255, 0.35);
+      }
+
+      .puzzle-piece.color-1 {
+        background: linear-gradient(145deg, rgba(91, 141, 239, 0.35), rgba(8, 32, 68, 0.7));
+        border-color: rgba(91, 141, 239, 0.4);
+      }
+
+      .puzzle-piece.color-2 {
+        background: linear-gradient(145deg, rgba(63, 224, 163, 0.3), rgba(4, 40, 48, 0.7));
+        border-color: rgba(63, 224, 163, 0.38);
+      }
+
+      .puzzle-piece.color-3 {
+        background: linear-gradient(145deg, rgba(138, 125, 255, 0.32), rgba(23, 24, 72, 0.7));
+        border-color: rgba(138, 125, 255, 0.4);
       }
 
       .logs-panel {
@@ -555,20 +582,29 @@
         const grid = document.getElementById('puzzle-grid');
         grid.innerHTML = '';
         const maxCount = Math.max(...data.map(item => item.result_count || 0), 1);
+        const paletteClasses = ['color-0', 'color-1', 'color-2', 'color-3'];
         if (!data.length) {
           const placeholder = document.createElement('div');
-          placeholder.className = 'puzzle-piece';
+          placeholder.className = 'puzzle-piece color-0';
           placeholder.innerHTML = '<strong>等待数据</strong><span>暂无访问记录</span>';
           grid.appendChild(placeholder);
           return;
         }
-        data.forEach(item => {
+        data.forEach((item, index) => {
           const piece = document.createElement('div');
           const weight = item.result_count / maxCount;
-          const span = Math.max(1, Math.round(weight * 3));
-          piece.className = 'puzzle-piece';
-          piece.style.gridColumn = `span ${span}`;
-          piece.style.gridRow = `span ${span}`;
+          let columnSpan = 1;
+          let rowSpan = 1;
+          if (weight >= 0.7) {
+            columnSpan = 2;
+            rowSpan = 2;
+          } else if (weight >= 0.4) {
+            columnSpan = 2;
+          }
+          const colorClass = paletteClasses[index % paletteClasses.length];
+          piece.className = `puzzle-piece ${colorClass}`;
+          piece.style.gridColumn = `span ${columnSpan}`;
+          piece.style.gridRow = `span ${rowSpan}`;
           piece.innerHTML = `
             <strong>${item.name}</strong>
             <span>${formatter.format(item.result_count)} 次访问</span>


### PR DESCRIPTION
## Summary
- ensure the cockpit watched websites list uses fixed widths, wraps long text, and avoids in-panel scroll bars
- enlarge the puzzle visit count labels and balance tile sizing with a four-color technology palette

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0cc0080488320b5e19b3670207c07