### PR TITLE
Adjust JSON API title handling and form toggles

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1446,9 +1446,12 @@ def run_task(task_id: int) -> None:
                     add_detail(f"详情页抓取失败：{link}", "warning")
                     subpage_errors.append(link)
                     continue
-                title, summary = summarize_html(link_html, website)
-                if not _is_non_empty_text(title):
-                    title = item["title"]
+                page_title, summary = summarize_html(link_html, website)
+                api_title = item.get("title")
+                if website.api_title_path:
+                    title = api_title if _is_non_empty_text(api_title) else page_title
+                else:
+                    title = page_title if _is_non_empty_text(page_title) else api_title
                 LOGGER.info(
                     "Task %s fetched API detail %s title: %s",
                     task.name,

--- a/templates/websites/form.html
+++ b/templates/websites/form.html
@@ -122,10 +122,19 @@
     var detailConfig = document.getElementById('detailConfig');
     var useProxyCheckbox = document.getElementById('useProxy');
     var proxyAdvanced = document.getElementById('proxyAdvanced');
+    var apiTitlePathInput = document.querySelector('input[name="api_title_path"]');
+
+    function hasApiTitlePath() {
+      return isJsonApiCheckbox.checked && apiTitlePathInput && apiTitlePathInput.value.trim() !== '';
+    }
 
     function toggleDetailSelectors() {
       if (isJsonApiCheckbox.checked) {
-        detailSelectors.classList.add('d-none');
+        if (hasApiTitlePath()) {
+          detailSelectors.classList.add('d-none');
+        } else {
+          detailSelectors.classList.remove('d-none');
+        }
         return;
       }
 
@@ -140,7 +149,11 @@
       if (isJsonApiCheckbox.checked) {
         jsonApiConfig.classList.remove('d-none');
         listConfig.classList.add('d-none');
-        detailConfig.classList.add('d-none');
+        if (hasApiTitlePath()) {
+          detailConfig.classList.add('d-none');
+        } else {
+          detailConfig.classList.remove('d-none');
+        }
       } else {
         jsonApiConfig.classList.add('d-none');
         listConfig.classList.remove('d-none');
@@ -163,6 +176,11 @@
     fetchSubpagesCheckbox.addEventListener('change', toggleDetailSelectors);
     isJsonApiCheckbox.addEventListener('change', toggleJsonApiConfig);
     useProxyCheckbox.addEventListener('change', toggleProxyConfig);
+    if (apiTitlePathInput) {
+      apiTitlePathInput.addEventListener('input', function () {
+        toggleJsonApiConfig();
+      });
+    }
   });
 </script>
 


### PR DESCRIPTION
## Summary
- prefer JSON API provided titles for subpages while retaining HTML fallbacks when needed
- update the website form toggles so detail settings remain visible when no API title path is configured

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0cfac63a4832097a91d8d4521fb4a