### PR TITLE
Update Flask server port to 5005

### DIFF
--- a/app.py
+++ b/app.py
@@ -1606,4 +1606,4 @@ def delete_proxy_endpoint(proxy_id: int) -> Any:
 if __name__ == "__main__":
     init_db()
     scheduler.start()
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5005, debug=True)


### PR DESCRIPTION
## Summary
- update the Flask application's startup port from 5000 to 5005

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d37f07c083209c356942644e5315