### PR TITLE
docs: refresh README and add Docker packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Pre-create runtime directories that should be mounted from the host.
+RUN mkdir -p /data /uploads
+
+ENV DATABASE_URL=sqlite:////data/data.db
+
+EXPOSE 5000
+
+CMD ["python", "-m", "flask", "--app", "app", "run", "--host=0.0.0.0", "--port=5000"]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,81 @@
-# 政策监控平台
+# 政策监控平台（Policy Monitor）
 
-本项目实现了一个可配置的政策信息监控平台，包含基础的站点配置、关注内容管理、监控任务执行与结果归档等功能，适合部署在轻量级服务器上进行日常监测。
+一个可配置的政策信息监控平台，支持多站点抓取、智能匹配与通知推送，帮助团队快速洞察政策动态、形成结构化的监测闭环。
 
-## 功能概览
+## 功能预览
 
-- **关注网站管理**：配置站点名称、入口 URL、是否抓取子页面、抓取时间间隔以及最后一次抓取时间，支持增删改查。
-- **关注内容清单**：维护需要重点关注的内容摘要（每条不超过 50 个字符），可用于多任务复用。
-- **监控任务管理**：绑定关注站点和关注内容，配置通知邮箱，支持启动/暂停任务，并展示最近执行日志及状态。
-- **监控结果归档**：记录每次抓取的匹配内容，支持按任务、站点、关注内容及时间范围筛选，并提供分页浏览。
-- **自动抓取与通知**：随服务启动自动运行调度器，按网站配置的时间间隔抓取页面，比较页面增量链接，利用 BERT 语义相似度筛选内容并通过 SMTP 邮件发送提醒，同时完整记录执行日志。
+| 驾驶舱总览 | 任务编排 | 结果归档 |
+| --- | --- | --- |
+| ![驾驶舱界面示意](docs/images/dashboard.svg) | ![任务中心示意](docs/images/tasks.svg) | ![结果归档示意](docs/images/results.svg) |
 
-## 技术栈
+> 上图展示了平台核心页面的视觉示意：驾驶舱实时汇总监测概况、任务中心支持精细化调度、结果归档聚合命中内容以便复核与追踪。
 
-- 前端：Flask + Jinja2 模板 + Bootstrap 5（无需复杂构建工具，便于维护与阅读）。
-- 后端：Python 3、Flask、SQLAlchemy。
-- 数据库：SQLite，默认存储在项目根目录的 `data.db`。
-- NLP：使用 `sentence-transformers` 的 `all-MiniLM-L6-v2` 模型计算关注内容与网页摘要的大意相似度。
-- 定时任务：内置后台线程调度，根据任务关联的网站抓取频率执行。
+## 核心功能
 
-## 快速开始
+- **关注网站管理**：支持站点基础配置、选择是否抓取子页面、配置抓取频率与代理策略。
+- **关注内容与分类**：以关键词或摘要的形式维护监控重点，可按分类复用到多个任务。
+- **监控任务编排**：将站点、关注内容、通知渠道组合成任务，可启停、查看日志与运行状态。
+- **抓取与比对引擎**：自动检测页面新增链接、解析内容摘要，并依据语义相似度命中政策资讯。
+- **多渠道通知**：内置 SMTP 邮件发送，并预留钉钉 webhook 扩展能力。
+- **驾驶舱与可视化**：提供高对比度驾驶舱，展示站点贡献度、执行队列、实时日志等指标。
 
-1. **安装依赖**
+## 技术亮点
+
+- **Flask + SQLAlchemy**：轻量稳定的 Web/ORM 组合，便于快速二次开发与迁移。
+- **可插拔的 NLP 匹配**：优先使用 `sentence-transformers`（`all-MiniLM-L6-v2`），在缺少依赖时自动回退到模糊匹配。
+- **后台调度器**：`MonitorScheduler` 在应用内常驻线程调度抓取任务，并支持运行时热加载代理配置。
+- **可观测性设计**：抓取日志、通知日志、监测结果全部结构化入库，可通过 UI 或自定义 SQL 复盘。
+- **代理与节流**：内建代理池管理与请求节流，适配受限站点访问策略。
+
+## 架构一览
+
+```mermaid
+flowchart LR
+    subgraph UI
+        A[管理界面<br/>Flask + Jinja2]
+    end
+    subgraph Backend
+        B[Flask 路由]
+        C[MonitorScheduler 调度线程]
+        D[crawler.py 抓取与比对]
+        E[nlp.py 语义匹配]
+    end
+    subgraph Services
+        F[(SQLite/关系型数据库)]
+        G[SMTP/钉钉通知]
+        H[可选代理池]
+    end
+
+    A --> B
+    B --> F
+    B --> C
+    C --> D
+    D --> F
+    D --> E
+    D --> G
+    D --> H
+```
+
+## 目录结构
+
+```
+.
+├── app.py                 # Flask 应用入口与路由
+├── crawler.py             # 抓取、对比与通知逻辑
+├── database.py            # 数据库会话及环境变量覆盖支持
+├── email_utils.py         # SMTP/钉钉通知封装
+├── models.py              # SQLAlchemy 模型定义
+├── scheduler.py           # 后台调度器
+├── templates/             # 前端模板（管理界面与驾驶舱）
+├── docs/images/           # 功能示意图资源
+├── docs/previews/         # HTML 预览（截图用演示数据）
+├── requirements.txt       # Python 依赖列表
+└── Dockerfile             # Docker 构建脚本
+```
+
+## 快速开始（开发模式）
+
+1. **创建虚拟环境并安装依赖**
 
    ```bash
    python3 -m venv .venv
@@ -29,24 +84,20 @@
    python -m pip install -r requirements.txt
    ```
 
-   > 💡 为避免 `python`、`pip` 与 `flask` 指向不同解释器，请始终通过 `python -m ...` 的形式安装依赖和启动服务。
+   如需启用语义匹配模型，确保能够安装 `sentence-transformers` 所需依赖（部分 Python 版本暂未提供预编译轮子）。
 
-   如需启用 BERT 语义模型，可额外安装（如当前 Python 版本支持）：
+2. **配置通知渠道**
 
-   ```bash
-   python -m pip install sentence-transformers numpy scipy
-   ```
-
-2. **配置 SMTP**
-
-   运行前请在环境变量或 `app.py` 中配置以下参数：
+   在环境变量或 `app.py` 中配置以下 SMTP 变量：
 
    - `SMTP_HOST`
    - `SMTP_PORT`
    - `SMTP_USERNAME`
    - `SMTP_PASSWORD`
-   - `SMTP_USE_TLS`（可选，默认为 `true`）
+   - `SMTP_USE_TLS`（可选，默认 `true`）
    - `SMTP_SENDER`（可选，默认与用户名一致）
+
+   若使用钉钉 webhook，参考 `email_utils.py` 内的 `send_dingtalk_message`。
 
 3. **启动服务**
 
@@ -54,46 +105,64 @@
    python -m flask --app app run
    ```
 
-   首次启动会自动初始化数据库并启动监控调度器。
+   首次启动会自动初始化数据库、导入示例代理并启动调度器。
 
-4. **访问平台**
+4. **访问管理界面**
 
-   浏览器打开 `http://localhost:5000`，即可进行站点、关注内容、监控任务的配置与管理。
+   浏览器打开 [http://localhost:5000](http://localhost:5000) 即可开始配置站点、关键词与监控任务。
 
-## 工作原理
+## Docker 部署
 
-1. 调度器按照配置的时间间隔触发监控任务，抓取站点首页 HTML。
-2. 将最新 HTML 与站点上一次的快照对比，找出新增链接（可根据配置决定是否处理子页面）。
-3. 对新增链接逐一抓取，提取标题与正文摘要。
-4. 使用 BERT 模型计算摘要与关注内容的语义相似度，超过 0.6 即视为命中。
-5. 命中后保存结果记录，并通过邮件推送标题、链接和摘要；所有步骤均写入执行日志，便于排查。
+1. **准备运行目录**（用于持久化数据库与上传文件）：
 
-## 注意事项
+   ```bash
+   mkdir -p runtime/data runtime/uploads
+   ```
 
-- 若未安装 `sentence-transformers`（例如在暂不提供相应轮子的 Python 3.13 环境），系统会回退到内置的模糊匹配算法，依然可以正常运行，只是相似度精度略低。若之后补充安装了 `sentence-transformers`，重新启动服务即可自动启用语义模型。
-- 如果站点页面结构复杂，可根据实际情况在 `crawler.py` 中扩展解析与差异检测逻辑。
-- 默认示例 SMTP 配置仅为占位，请务必使用真实的邮件服务账号。
+2. **构建镜像**
 
-## 目录结构
+   ```bash
+   docker build -t policy-monitor:latest .
+   ```
 
-```
-.
-├── app.py                # Flask 应用入口及路由
-├── crawler.py            # 抓取、对比与通知逻辑
-├── database.py           # 数据库初始化与会话管理
-├── email_utils.py        # SMTP 邮件发送封装
-├── models.py             # SQLAlchemy 数据模型
-├── nlp.py                # BERT 语义相似度工具
-├── scheduler.py          # 后台任务调度
-├── templates/            # 页面模板
-├── requirements.txt      # 依赖列表
-└── data.db               # 运行后生成的 SQLite 数据库
-```
+3. **运行容器**
 
-## 开发与扩展建议
+   ```bash
+   docker run -d \
+     --name policy-monitor \
+     -p 5000:5000 \
+     -e FLASK_ENV=production \
+     -e DATABASE_URL=sqlite:////data/data.db \
+     -e SMTP_HOST=smtp.example.com \
+     -e SMTP_PORT=465 \
+     -e SMTP_USERNAME=notify@example.com \
+     -e SMTP_PASSWORD=secret \
+     -e SMTP_USE_TLS=true \
+     -v $(pwd)/runtime/data:/data \
+     -v $(pwd)/runtime/uploads:/uploads \
+     policy-monitor:latest
+   ```
 
-- 可按需将后台调度改造为 APScheduler 或 Celery，以便水平扩展与错峰执行。
-- 邮件通知可替换为企业微信、钉钉或短信等渠道，仅需在 `notify` 函数内调整实现。
-- 若需更精细的差异检测，可将站点快照存储为结构化数据并结合 diff 算法分析。
+   - `/data` 卷用于保存 `data.db` 等数据库文件。
+   - `/uploads` 卷可用于扩展存储附件、报告或快照等文件。
+   - 如需暴露其他服务端口（例如自定义 API），可在 `docker run` 时追加 `-p` 参数。
 
-欢迎根据业务需求进行二次开发与部署。
+4. **日志与升级**
+
+   - 查看运行日志：`docker logs -f policy-monitor`
+   - 升级版本：停止并删除旧容器，重新构建镜像并挂载同一数据卷即可保留历史数据。
+
+## 运维提示
+
+- 若运行环境无法安装 `sentence-transformers`，系统会退回到模糊匹配算法，仍可正常使用。
+- 对请求频率敏感的站点可在站点配置中启用代理并设定节流参数。
+- 建议配合定时备份 `/data` 卷，以防数据库损坏或误操作。
+- 可通过扩展 `email_utils.py` 或新增通知适配器，整合企业微信、飞书等渠道。
+
+## 开发者路线图
+
+- 引入 APScheduler/Celery 以支持分布式调度。
+- 增强抓取规则管理，提供可视化 XPath/JSONPath 配置。
+- 新增多租户隔离、访问控制与审计功能。
+
+欢迎提交 Issue 或 PR，共同完善政策监控平台。

--- a/database.py
+++ b/database.py
@@ -1,7 +1,21 @@
+from __future__ import annotations
+
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker, declarative_base
 
-DATABASE_URL = "sqlite:///data.db"
+
+def _resolve_database_url() -> str:
+    """Return the configured database URL with environment override support."""
+
+    override = os.getenv("DATABASE_URL")
+    if override:
+        return override
+    return "sqlite:///data.db"
+
+
+DATABASE_URL = _resolve_database_url()
 
 engine = create_engine(
     DATABASE_URL,

--- a/docs/images/dashboard.svg
+++ b/docs/images/dashboard.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#04152d"/>
+      <stop offset="0.6" stop-color="#03142a"/>
+      <stop offset="1" stop-color="#041029"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0b274f"/>
+      <stop offset="1" stop-color="#092038"/>
+    </linearGradient>
+    <linearGradient id="highlight" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#00b5ff" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="#00b5ff" stop-opacity="0.6"/>
+    </linearGradient>
+    <style>
+      text { font-family: 'Segoe UI', 'PingFang SC', sans-serif; fill: #e6f3ff; }
+      .title { font-size: 32px; letter-spacing: 6px; text-transform: uppercase; }
+      .panel-title { font-size: 20px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; }
+      .small { font-size: 14px; fill: #6f9ac3; }
+      .count { font-size: 36px; font-weight: 600; fill: #00c6ff; text-anchor: end; }
+    </style>
+  </defs>
+  <rect width="1280" height="720" fill="url(#bg)"/>
+  <text x="80" y="90" class="title">POLICY MONITOR</text>
+  <!-- left panel -->
+  <g transform="translate(60,140)">
+    <rect width="300" height="440" rx="26" fill="url(#card)" stroke="#144a77" stroke-opacity="0.3" stroke-width="2"/>
+    <text x="24" y="48" class="panel-title">站点覆盖</text>
+    <text x="264" y="48" text-anchor="end" class="small">更新：2024-11-30 12:30:12</text>
+    <g transform="translate(24,80)">
+      <rect width="252" height="78" rx="16" fill="#0d1f3c" stroke="#123c66"/>
+      <text x="12" y="28" font-size="18" font-weight="600">国家发展改革委</text>
+      <text x="12" y="54" class="small">https://www.ndrc.gov.cn</text>
+      <text x="240" y="48" class="count">128</text>
+      <rect x="12" y="60" width="228" height="8" rx="4" fill="#0a1a33"/>
+      <rect x="12" y="60" width="216" height="8" rx="4" fill="url(#highlight)"/>
+    </g>
+    <g transform="translate(24,170)">
+      <rect width="252" height="78" rx="16" fill="#0d1f3c" stroke="#123c66"/>
+      <text x="12" y="28" font-size="18" font-weight="600">工业和信息化部</text>
+      <text x="12" y="54" class="small">https://www.miit.gov.cn</text>
+      <text x="240" y="48" class="count">96</text>
+      <rect x="12" y="60" width="228" height="8" rx="4" fill="#0a1a33"/>
+      <rect x="12" y="60" width="180" height="8" rx="4" fill="url(#highlight)"/>
+    </g>
+    <g transform="translate(24,260)">
+      <rect width="252" height="78" rx="16" fill="#0d1f3c" stroke="#123c66"/>
+      <text x="12" y="28" font-size="18" font-weight="600">深圳发改委</text>
+      <text x="12" y="54" class="small">https://fzgg.sz.gov.cn</text>
+      <text x="240" y="48" class="count">54</text>
+      <rect x="12" y="60" width="228" height="8" rx="4" fill="#0a1a33"/>
+      <rect x="12" y="60" width="120" height="8" rx="4" fill="url(#highlight)"/>
+    </g>
+    <g transform="translate(24,356)">
+      <text x="0" y="0" class="panel-title">高频关键词</text>
+      <rect y="16" width="252" height="72" rx="16" fill="#0d1f3c" stroke="#123c66"/>
+      <text x="20" y="46" font-size="16">智能制造</text>
+      <text x="232" y="46" text-anchor="end" font-size="20" fill="#00c6ff">42</text>
+      <text x="20" y="74" font-size="16">专精特新</text>
+      <text x="232" y="74" text-anchor="end" font-size="20" fill="#00c6ff">35</text>
+    </g>
+  </g>
+  <!-- center heatmap -->
+  <g transform="translate(400,140)">
+    <rect width="520" height="440" rx="26" fill="#0d1f3c" stroke="#123c66" stroke-opacity="0.4"/>
+    <text x="32" y="48" class="panel-title">监测热点分布</text>
+    <text x="480" y="48" text-anchor="end" class="small">更新：2024-11-30 12:30</text>
+    <g transform="translate(32,80)">
+      <rect width="260" height="200" rx="22" fill="#0f3b63" stroke="#1b6ca3" stroke-opacity="0.6"/>
+      <text x="24" y="52" font-size="22">国家发展改革委</text>
+      <text x="24" y="90" class="small">128 次访问</text>
+    </g>
+    <g transform="translate(312,80)">
+      <rect width="176" height="120" rx="22" fill="#123257" stroke="#1b6ca3" stroke-opacity="0.4"/>
+      <text x="24" y="52" font-size="20">工业和信息化部</text>
+      <text x="24" y="86" class="small">96 次访问</text>
+    </g>
+    <g transform="translate(312,220)">
+      <rect width="176" height="120" rx="22" fill="#1a3052" stroke="#1b6ca3" stroke-opacity="0.2"/>
+      <text x="24" y="52" font-size="20">地方发改委</text>
+      <text x="24" y="86" class="small">54 次访问</text>
+    </g>
+    <g transform="translate(32,300)">
+      <rect width="180" height="100" rx="22" fill="#1c2f4a" stroke="#1b6ca3" stroke-opacity="0.2"/>
+      <text x="24" y="44" font-size="20">工信厅</text>
+      <text x="24" y="78" class="small">38 次访问</text>
+    </g>
+  </g>
+  <!-- right column -->
+  <g transform="translate(960,140)">
+    <rect width="260" height="210" rx="26" fill="url(#card)" stroke="#144a77" stroke-opacity="0.3"/>
+    <text x="24" y="48" class="panel-title">执行中的任务</text>
+    <g transform="translate(24,76)">
+      <text font-size="18" font-weight="600">制造业扶持政策</text>
+      <text y="28" class="small">工业和信息化部 · 启动于 12:28</text>
+    </g>
+    <g transform="translate(24,132)">
+      <text font-size="18" font-weight="600">专精特新快讯</text>
+      <text y="28" class="small">国家发展改革委 · 启动于 12:25</text>
+    </g>
+  </g>
+  <g transform="translate(960,374)">
+    <rect width="260" height="206" rx="26" fill="url(#card)" stroke="#144a77" stroke-opacity="0.3"/>
+    <text x="24" y="48" class="panel-title">通知动态</text>
+    <g transform="translate(24,78)">
+      <text font-size="18" font-weight="600" fill="#00c6ff">专精特新快讯</text>
+      <text y="26" class="small">检测到「关于推动产业数字化发展的指导意见」</text>
+      <text y="52" class="small">12:26 · 已送达</text>
+    </g>
+    <g transform="translate(24,134)">
+      <text font-size="18" font-weight="600" fill="#00c6ff">制造业扶持政策</text>
+      <text y="26" class="small">任务失败，将在 5 分钟后重试</text>
+      <text y="52" class="small">12:28 · 重试中</text>
+    </g>
+  </g>
+  <g transform="translate(400,600)">
+    <rect width="520" height="120" rx="22" fill="url(#card)" stroke="#144a77" stroke-opacity="0.3"/>
+    <text x="32" y="46" class="panel-title">实时日志</text>
+    <text x="32" y="88" class="small">12:30:12 任务「专精特新快讯」抓取成功 · 12:29:48 代理节点更新完成 · 12:28:03 抓取失败自动重试</text>
+  </g>
+  <text x="60" y="660" class="small">政策监控驾驶舱 · 示意界面</text>
+  <text x="1220" y="660" text-anchor="end" class="small">12:30:18</text>
+</svg>

--- a/docs/images/results.svg
+++ b/docs/images/results.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="space" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111c34"/>
+    </linearGradient>
+    <style>
+      text { font-family: 'Segoe UI', 'PingFang SC', sans-serif; fill: #e2e8f0; }
+      .muted { fill: #94a3b8; }
+      .title { font-size: 30px; font-weight: 600; }
+      .card { fill: rgba(30,41,59,0.85); stroke: rgba(148,163,184,0.3); }
+    </style>
+  </defs>
+  <rect width="1280" height="720" fill="url(#space)"/>
+  <rect y="0" width="1280" height="140" fill="rgba(14,38,74,0.9)"/>
+  <text x="80" y="88" class="title">监控结果归档</text>
+  <text x="80" y="118" class="muted" font-size="18">智能抓取最新政策资讯，并按任务、站点和关注内容归档显示</text>
+  <g transform="translate(80,180)">
+    <rect width="320" height="440" rx="26" fill="rgba(15,23,42,0.85)" stroke="rgba(148,163,184,0.3)"/>
+    <text x="24" y="48" font-size="18" letter-spacing="2" class="muted">筛选条件</text>
+    <text x="24" y="96" class="muted" font-size="12">监测任务</text>
+    <rect x="24" y="108" width="272" height="40" rx="12" fill="rgba(15,23,42,0.6)" stroke="rgba(148,163,184,0.3)"/>
+    <text x="40" y="134">专精特新政策速递</text>
+    <text x="24" y="184" class="muted" font-size="12">关联网站</text>
+    <rect x="24" y="196" width="272" height="40" rx="12" fill="rgba(15,23,42,0.6)" stroke="rgba(148,163,184,0.3)"/>
+    <text x="40" y="222">国家发展改革委</text>
+    <text x="24" y="272" class="muted" font-size="12">关注关键词</text>
+    <rect x="24" y="284" width="272" height="40" rx="12" fill="rgba(15,23,42,0.6)" stroke="rgba(148,163,184,0.3)"/>
+    <text x="40" y="310">数字化转型</text>
+    <text x="24" y="360" class="muted" font-size="12">时间范围</text>
+    <rect x="24" y="372" width="272" height="40" rx="12" fill="rgba(15,23,42,0.6)" stroke="rgba(148,163,184,0.3)"/>
+    <text x="40" y="398">2024-11-01 ~ 2024-11-30</text>
+    <rect x="24" y="440" width="272" height="44" rx="14" fill="url(#space)" stroke="#38bdf8" stroke-opacity="0.7"/>
+    <text x="136" y="470" text-anchor="middle" font-size="14">立即筛选</text>
+  </g>
+  <g transform="translate(440,180)">
+    <rect width="760" height="440" rx="26" fill="rgba(15,23,42,0.75)" stroke="rgba(148,163,184,0.3)"/>
+    <g transform="translate(32,40)">
+      <rect width="696" height="164" rx="20" class="card"/>
+      <text x="24" y="36" fill="#cbd5f5">专精特新政策速递 · 国家发展改革委</text>
+      <text x="24" y="74" font-size="20" font-weight="600" fill="#38bdf8">关于推动产业数字化发展的指导意见</text>
+      <text x="24" y="108" class="muted">提出到 2027 年建成覆盖重点产业的智能化政策服务体系，明确对符合条件的专精特新企业给予资金支持与税收优惠。</text>
+      <text x="520" y="74" font-size="14" fill="#34d399">语义匹配度 0.87</text>
+      <text x="520" y="102" class="muted">2024-11-30 12:18</text>
+      <text x="520" y="132" class="muted">来源：国家发展改革委</text>
+    </g>
+    <g transform="translate(32,220)">
+      <rect width="696" height="164" rx="20" class="card"/>
+      <text x="24" y="36" fill="#cbd5f5">制造业扶持政策 · 工业和信息化部</text>
+      <text x="24" y="74" font-size="20" font-weight="600" fill="#38bdf8">关于征集2025年度智能制造示范工厂的通知</text>
+      <text x="24" y="108" class="muted">面向高端装备、电子信息等重点行业征集智能制造示范工厂项目，要求同步提交项目实施方案与技术改造预算。</text>
+      <text x="520" y="74" font-size="14" fill="#34d399">语义匹配度 0.81</text>
+      <text x="520" y="102" class="muted">2024-11-29 18:42</text>
+      <text x="520" y="132" class="muted">来源：工业和信息化部</text>
+    </g>
+  </g>
+</svg>

--- a/docs/images/tasks.svg
+++ b/docs/images/tasks.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720">
+  <defs>
+    <linearGradient id="header" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f6eff"/>
+      <stop offset="1" stop-color="#42b9ff"/>
+    </linearGradient>
+    <style>
+      text { font-family: 'Segoe UI', 'PingFang SC', sans-serif; fill: #1f2933; }
+      .white { fill: #fff; }
+      .subtitle { fill: rgba(255,255,255,0.85); }
+      .badge { font-size: 14px; font-weight: 600; fill: #0f6eff; }
+      .pill { font-size: 12px; fill: #4338ca; }
+      .muted { fill: #6b7280; font-size: 12px; }
+    </style>
+  </defs>
+  <rect width="1280" height="720" fill="#f3f6fb"/>
+  <rect width="1280" height="160" fill="url(#header)"/>
+  <text x="80" y="88" font-size="32" font-weight="600" class="white">监控任务中心</text>
+  <text x="80" y="120" font-size="18" class="subtitle">集中展示所有关注站点的监测任务与调度状态</text>
+  <g transform="translate(80,200)">
+    <rect width="1120" height="420" rx="26" fill="#fff" stroke="#d5e3ff" stroke-opacity="0.6"/>
+    <g transform="translate(32,40)">
+      <text y="0" font-size="14" fill="#5f6b7c">任务名称</text>
+      <text x="220" y="0" font-size="14" fill="#5f6b7c">监测网站</text>
+      <text x="360" y="0" font-size="14" fill="#5f6b7c">关注内容</text>
+      <text x="620" y="0" font-size="14" fill="#5f6b7c">最后执行</text>
+      <text x="780" y="0" font-size="14" fill="#5f6b7c">下一次执行</text>
+      <text x="920" y="0" font-size="14" fill="#5f6b7c">任务状态</text>
+      <text x="1040" y="0" font-size="14" fill="#5f6b7c">执行状态</text>
+    </g>
+    <g transform="translate(32,80)">
+      <rect width="1056" height="140" rx="20" fill="#f8fbff" stroke="#deebff"/>
+      <text x="20" y="36" class="badge">🛰 自动监控</text>
+      <text x="20" y="68" font-size="20" font-weight="600">专精特新政策速递</text>
+      <text x="220" y="52" font-size="16">国家发展改革委</text>
+      <text x="360" y="44" class="pill" font-size="12">产业政策 · 数字化转型</text>
+      <text x="360" y="72" class="pill" font-size="12">制造业 · 专精特新</text>
+      <text x="620" y="48" fill="#0f6eff" font-size="16">2024-11-30 12:20</text>
+      <text x="620" y="74" class="muted">UTC+08</text>
+      <text x="780" y="48" fill="#0991c7" font-size="16">12 分钟后</text>
+      <text x="780" y="74" class="muted">计划于 12:32</text>
+      <text x="920" y="48" fill="#0f9d58" font-size="16">🟢 已启用</text>
+      <text x="1040" y="48" fill="#b45309" font-size="16">⏳ 执行中</text>
+    </g>
+    <g transform="translate(32,240)">
+      <rect width="1056" height="140" rx="20" fill="#f8fbff" stroke="#deebff"/>
+      <text x="20" y="36" class="badge">🛰 自动监控</text>
+      <text x="20" y="68" font-size="20" font-weight="600">制造业扶持政策</text>
+      <text x="220" y="52" font-size="16">工业和信息化部</text>
+      <text x="360" y="44" class="pill">补贴申请</text>
+      <text x="360" y="72" class="pill">项目公示</text>
+      <text x="620" y="48" fill="#0f6eff" font-size="16">2024-11-30 11:55</text>
+      <text x="620" y="74" class="muted">UTC+08</text>
+      <text x="780" y="48" fill="#0991c7" font-size="16">5 分钟后</text>
+      <text x="780" y="74" class="muted">计划于 12:25</text>
+      <text x="920" y="48" fill="#0f9d58" font-size="16">🟢 已启用</text>
+      <text x="1040" y="48" fill="#6b7280" font-size="16">⚙️ 等待调度</text>
+    </g>
+    <text x="32" y="404" class="muted">数据来自演示环境，实际运行时将实时更新</text>
+  </g>
+</svg>

--- a/docs/previews/dashboard.html
+++ b/docs/previews/dashboard.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>政策监控驾驶舱（演示数据）</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-dark: #020b1e;
+      --bg-panel: rgba(7, 23, 52, 0.7);
+      --bg-panel-solid: #071734;
+      --accent: #00c6ff;
+      --accent-soft: rgba(0, 198, 255, 0.35);
+      --text-main: #e6f3ff;
+      --text-dim: #6f9ac3;
+      --success: #3fe0a3;
+      --danger: #ff6b8a;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Rajdhani', 'Segoe UI', sans-serif;
+      color: var(--text-main);
+      background: radial-gradient(circle at 20% 20%, rgba(0, 198, 255, 0.1), transparent 40%),
+                  radial-gradient(circle at 80% 0%, rgba(99, 102, 241, 0.15), transparent 55%),
+                  linear-gradient(135deg, #010409, #020b1e 70%, #031435);
+      display: flex;
+      flex-direction: column;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 24px 48px 16px;
+    }
+    .brand {
+      font-size: 28px;
+      font-weight: 600;
+      letter-spacing: 6px;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .brand::before {
+      content: '';
+      width: 10px;
+      height: 32px;
+      background: linear-gradient(180deg, var(--accent), transparent);
+      border-radius: 4px;
+    }
+    .nav-actions { display: flex; gap: 12px; }
+    .nav-actions a {
+      text-decoration: none;
+      color: var(--text-main);
+      border: 1px solid rgba(0, 198, 255, 0.35);
+      padding: 10px 18px;
+      border-radius: 999px;
+      font-size: 14px;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      background: rgba(0, 198, 255, 0.08);
+      box-shadow: 0 0 12px rgba(0, 198, 255, 0.15) inset;
+    }
+    main {
+      flex: 1;
+      padding: 0 48px 32px;
+      display: grid;
+      grid-template-columns: 320px minmax(0, 1fr) 320px;
+      gap: 28px;
+    }
+    .panel {
+      background: var(--bg-panel);
+      border: 1px solid rgba(0, 198, 255, 0.15);
+      border-radius: 18px;
+      padding: 20px 22px;
+      backdrop-filter: blur(8px);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+      position: relative;
+      overflow: hidden;
+    }
+    .panel h2 {
+      margin: 0 0 12px;
+      font-size: 18px;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+    }
+    .panel h2 span { font-size: 12px; color: var(--text-dim); margin-left: 10px; }
+    .websites-list { display: flex; flex-direction: column; gap: 12px; }
+    .website-item {
+      background: var(--bg-panel-solid);
+      border-radius: 14px;
+      padding: 14px 16px;
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 8px;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+    }
+    .website-item strong { font-size: 16px; display: block; overflow-wrap: anywhere; }
+    .website-item .meta { font-size: 12px; color: var(--text-dim); overflow-wrap: anywhere; }
+    .website-item .count { font-size: 20px; font-weight: 600; color: var(--accent); text-align: right; }
+    .website-item .progress { grid-column: span 2; height: 6px; border-radius: 999px; background: rgba(0, 198, 255, 0.1); overflow: hidden; }
+    .website-item .progress span {
+      display: block;
+      height: 100%;
+      border-radius: 999px;
+      background: linear-gradient(90deg, rgba(0, 198, 255, 0.2), var(--accent));
+      transform-origin: left;
+    }
+    .keywords-panel ul,
+    .tasks-panel ul,
+    .notifications-panel ul {
+      list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px;
+    }
+    .keywords-panel li {
+      display: flex; justify-content: space-between; align-items: center; padding: 10px 12px;
+      background: rgba(0, 198, 255, 0.05); border: 1px solid rgba(0, 198, 255, 0.1); border-radius: 10px;
+    }
+    .keywords-panel li span:last-child { font-weight: 600; color: var(--accent); }
+    .center-cluster { display: grid; grid-template-rows: minmax(0, 3fr) 160px; gap: 20px; }
+    .puzzle-wrapper {
+      position: relative; background: rgba(1, 14, 36, 0.85); border-radius: 18px;
+      border: 1px solid rgba(0, 198, 255, 0.2); padding: 24px; overflow: hidden; display: flex; flex-direction: column;
+    }
+    .puzzle-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+    .puzzle-grid {
+      flex: 1; display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      grid-auto-rows: 110px; gap: 14px; perspective: 800px;
+    }
+    .puzzle-piece {
+      position: relative; border-radius: 18px; border: 1px solid rgba(0, 198, 255, 0.25);
+      box-shadow: 0 20px 35px rgba(0, 0, 0, 0.45); padding: 16px; overflow: hidden;
+      display: flex; flex-direction: column; justify-content: space-between;
+      transform: rotateX(6deg); transition: transform 0.3s ease, box-shadow 0.3s ease;
+      background: linear-gradient(145deg, rgba(0, 198, 255, 0.2), rgba(2, 11, 30, 0.6));
+    }
+    .puzzle-piece strong { font-size: 18px; overflow-wrap: anywhere; }
+    .puzzle-piece span { font-size: 16px; color: var(--text-dim); font-weight: 600; }
+    .puzzle-piece.color-0 { background: linear-gradient(145deg, rgba(0, 198, 255, 0.28), rgba(1, 28, 58, 0.75)); border-color: rgba(0, 198, 255, 0.35); }
+    .puzzle-piece.color-1 { background: linear-gradient(145deg, rgba(91, 141, 239, 0.35), rgba(8, 32, 68, 0.7)); border-color: rgba(91, 141, 239, 0.4); }
+    .puzzle-piece.color-2 { background: linear-gradient(145deg, rgba(63, 224, 163, 0.3), rgba(4, 40, 48, 0.7)); border-color: rgba(63, 224, 163, 0.38); }
+    .puzzle-piece.color-3 { background: linear-gradient(145deg, rgba(138, 125, 255, 0.32), rgba(23, 24, 72, 0.7)); border-color: rgba(138, 125, 255, 0.4); }
+    .logs-panel { background: rgba(0,0,0,0.35); border-radius: 16px; border: 1px solid rgba(0, 198, 255, 0.2); padding: 16px 18px; font-family: 'Fira Code', ui-monospace; }
+    .logs-stream { max-height: 160px; overflow-y: auto; }
+    .logs-stream li { display: flex; gap: 12px; color: var(--text-dim); font-size: 13px; white-space: nowrap; }
+    .logs-stream li .time { color: var(--accent); }
+    .logs-stream li .level-error { color: var(--danger); }
+    .logs-stream li .level-success { color: var(--success); }
+    .sidebar { display: flex; flex-direction: column; gap: 24px; }
+    .tasks-panel li,
+    .notifications-panel li {
+      background: rgba(0, 198, 255, 0.06);
+      border: 1px solid rgba(0, 198, 255, 0.12);
+      border-radius: 12px;
+      padding: 12px 14px;
+      font-size: 13px;
+    }
+    .notifications-panel li strong { display: block; color: var(--accent); }
+    .timestamp { color: var(--text-dim); font-size: 12px; }
+    footer { padding: 12px 48px 24px; display: flex; justify-content: space-between; font-size: 12px; color: var(--text-dim); }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand">Policy Monitor</div>
+    <nav class="nav-actions">
+      <a href="#">站点管理</a>
+      <a href="#">关键词</a>
+      <a href="#">任务中心</a>
+      <a href="#">结果归档</a>
+    </nav>
+  </header>
+  <main>
+    <aside class="panel">
+      <h2>站点覆盖 <span>更新：2024-11-30 12:30:12</span></h2>
+      <div class="websites-list">
+        <div class="website-item">
+          <div>
+            <strong>国家发展改革委</strong>
+            <div class="meta">https://www.ndrc.gov.cn</div>
+          </div>
+          <div class="count">128</div>
+          <div class="progress"><span style="width: 100%"></span></div>
+        </div>
+        <div class="website-item">
+          <div>
+            <strong>工业和信息化部</strong>
+            <div class="meta">https://www.miit.gov.cn</div>
+          </div>
+          <div class="count">96</div>
+          <div class="progress"><span style="width: 75%"></span></div>
+        </div>
+        <div class="website-item">
+          <div>
+            <strong>深圳发改委</strong>
+            <div class="meta">https://fzgg.sz.gov.cn</div>
+          </div>
+          <div class="count">54</div>
+          <div class="progress"><span style="width: 42%"></span></div>
+        </div>
+      </div>
+      <section class="panel keywords-panel" style="margin-top:24px;">
+        <h2>高频关键词</h2>
+        <ul>
+          <li><span>智能制造</span><span>42</span></li>
+          <li><span>专精特新</span><span>35</span></li>
+          <li><span>高端装备</span><span>28</span></li>
+        </ul>
+      </section>
+    </aside>
+    <section class="center-cluster">
+      <div class="puzzle-wrapper">
+        <div class="puzzle-header">
+          <h2>监测热点分布</h2>
+          <span class="timestamp">更新：2024-11-30 12:30</span>
+        </div>
+        <div class="puzzle-grid">
+          <div class="puzzle-piece color-0" style="grid-column: span 2; grid-row: span 2;">
+            <strong>国家发展改革委</strong>
+            <span>128 次访问</span>
+          </div>
+          <div class="puzzle-piece color-1" style="grid-column: span 2;">
+            <strong>工业和信息化部</strong>
+            <span>96 次访问</span>
+          </div>
+          <div class="puzzle-piece color-2">
+            <strong>地方发改委</strong>
+            <span>54 次访问</span>
+          </div>
+          <div class="puzzle-piece color-3">
+            <strong>工信厅</strong>
+            <span>38 次访问</span>
+          </div>
+        </div>
+      </div>
+      <div class="panel logs-panel">
+        <h3>实时日志</h3>
+        <ul class="logs-stream">
+          <li><span class="time">12:30:12</span><span class="level-success">任务「专精特新快讯」抓取成功</span></li>
+          <li><span class="time">12:29:48</span><span>代理节点更新完成</span></li>
+          <li><span class="time">12:28:03</span><span class="level-error">任务「制造业扶持政策」抓取失败</span></li>
+          <li><span class="time">12:27:15</span><span>邮件通知已发送至 policy@corp.cn</span></li>
+        </ul>
+      </div>
+    </section>
+    <aside class="sidebar">
+      <section class="panel tasks-panel">
+        <h2>执行中的任务</h2>
+        <ul>
+          <li>
+            <div><strong>制造业扶持政策</strong></div>
+            <div class="timestamp">工业和信息化部 · 启动于 12:28</div>
+          </li>
+          <li>
+            <div><strong>专精特新快讯</strong></div>
+            <div class="timestamp">国家发展改革委 · 启动于 12:25</div>
+          </li>
+        </ul>
+      </section>
+      <section class="panel notifications-panel">
+        <h2>通知动态</h2>
+        <ul>
+          <li>
+            <strong>专精特新快讯</strong>
+            <div>检测到「关于推动产业数字化发展的指导意见」</div>
+            <div class="timestamp">12:26 · 已送达</div>
+          </li>
+          <li>
+            <strong>制造业扶持政策</strong>
+            <div>任务失败，将在 5 分钟后重试</div>
+            <div class="timestamp">12:28 · 重试中</div>
+          </li>
+        </ul>
+      </section>
+    </aside>
+  </main>
+  <footer>
+    <span>政策监控驾驶舱</span>
+    <span>12:30:18</span>
+  </footer>
+</body>
+</html>

--- a/docs/previews/results.html
+++ b/docs/previews/results.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>监控结果归档（演示数据）</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+    header { padding: 28px 40px; background: rgba(14, 38, 74, 0.95); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(148, 163, 184, 0.2); }
+    header h1 { margin: 0; font-size: 26px; }
+    header p { margin: 6px 0 0; color: #94a3b8; }
+    main { padding: 32px 40px; display: grid; grid-template-columns: 280px 1fr; gap: 28px; }
+    .filters { background: rgba(15, 23, 42, 0.85); border-radius: 18px; padding: 20px 22px; box-shadow: 0 18px 45px rgba(2, 6, 23, 0.6); border: 1px solid rgba(148, 163, 184, 0.12); }
+    .filters h2 { margin-top: 0; font-size: 16px; letter-spacing: 1px; text-transform: uppercase; color: #94a3b8; }
+    .filters label { display: block; font-size: 12px; margin-bottom: 6px; text-transform: uppercase; color: #64748b; }
+    .filters select,
+    .filters input { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid rgba(148, 163, 184, 0.3); background: rgba(15, 23, 42, 0.6); color: #e2e8f0; margin-bottom: 16px; }
+    .filters button { width: 100%; padding: 10px; border-radius: 12px; border: none; background: linear-gradient(135deg, #38bdf8, #6366f1); color: #fff; font-size: 13px; font-weight: 600; }
+    .results-panel { background: rgba(15, 23, 42, 0.75); border-radius: 18px; padding: 24px 26px; box-shadow: 0 18px 45px rgba(2, 6, 23, 0.6); border: 1px solid rgba(148, 163, 184, 0.12); display: flex; flex-direction: column; gap: 18px; }
+    .result-card { background: rgba(30, 41, 59, 0.85); border-radius: 16px; padding: 18px 20px; border: 1px solid rgba(148, 163, 184, 0.18); display: grid; grid-template-columns: 1fr auto; gap: 12px; }
+    .result-card h3 { margin: 0; font-size: 18px; color: #f1f5f9; }
+    .result-card p { margin: 6px 0 0; color: #cbd5f5; line-height: 1.6; }
+    .result-meta { font-size: 13px; color: #94a3b8; display: flex; flex-direction: column; gap: 6px; align-items: flex-end; }
+    .tag { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; background: rgba(99, 102, 241, 0.16); color: #c7d2fe; }
+    .score { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 12px; font-size: 13px; background: rgba(16, 185, 129, 0.15); color: #34d399; }
+    .link { color: #38bdf8; text-decoration: none; font-weight: 600; }
+    .link:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>监控结果归档</h1>
+    <p>智能抓取最新政策资讯，并按任务、站点和关注内容归档显示</p>
+  </header>
+  <main>
+    <aside class="filters">
+      <h2>筛选条件</h2>
+      <label>监测任务</label>
+      <select>
+        <option>全部任务</option>
+        <option>专精特新政策速递</option>
+        <option>制造业扶持政策</option>
+      </select>
+      <label>关联网站</label>
+      <select>
+        <option>全部站点</option>
+        <option>国家发展改革委</option>
+        <option>工业和信息化部</option>
+      </select>
+      <label>关注关键词</label>
+      <select>
+        <option>全部内容</option>
+        <option>数字化转型</option>
+        <option>补贴申请</option>
+      </select>
+      <label>时间范围</label>
+      <input type="text" value="2024-11-01 ~ 2024-11-30">
+      <button>立即筛选</button>
+    </aside>
+    <section class="results-panel">
+      <div class="result-card">
+        <div>
+          <div class="tag">专精特新政策速递 · 国家发展改革委</div>
+          <h3><a class="link" href="#">关于推动产业数字化发展的指导意见</a></h3>
+          <p>提出到 2027 年建成覆盖重点产业的智能化政策服务体系，明确对符合条件的专精特新企业给予资金支持与税收优惠。</p>
+        </div>
+        <div class="result-meta">
+          <span class="score">语义匹配度 0.87</span>
+          <span>2024-11-30 12:18</span>
+          <span>来源：国家发展改革委</span>
+        </div>
+      </div>
+      <div class="result-card">
+        <div>
+          <div class="tag">制造业扶持政策 · 工业和信息化部</div>
+          <h3><a class="link" href="#">关于征集2025年度智能制造示范工厂的通知</a></h3>
+          <p>面向高端装备、电子信息等重点行业征集智能制造示范工厂项目，要求同步提交项目实施方案与技术改造预算。</p>
+        </div>
+        <div class="result-meta">
+          <span class="score">语义匹配度 0.81</span>
+          <span>2024-11-29 18:42</span>
+          <span>来源：工业和信息化部</span>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/previews/tasks.html
+++ b/docs/previews/tasks.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <title>监控任务（演示数据）</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+      margin: 0;
+      background: #f3f6fb;
+      color: #1f2933;
+    }
+    header {
+      background: linear-gradient(135deg, #0f6eff, #42b9ff);
+      color: #fff;
+      padding: 24px 40px;
+      box-shadow: 0 10px 30px rgba(15, 110, 255, 0.25);
+    }
+    header h1 {
+      margin: 0 0 6px;
+      font-size: 28px;
+      letter-spacing: 1px;
+    }
+    header p { margin: 0; opacity: 0.85; }
+    main { padding: 32px 40px; }
+    table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 18px; overflow: hidden; box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08); }
+    thead { background: #f0f7ff; }
+    th, td { padding: 16px 18px; text-align: left; vertical-align: middle; }
+    th { font-size: 13px; text-transform: uppercase; letter-spacing: 1px; color: #5f6b7c; }
+    tbody tr + tr { border-top: 1px solid #eef2f7; }
+    .badge { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+    .badge-pill { border-radius: 999px; }
+    .badge-primary { background: rgba(15, 110, 255, 0.12); color: #0f6eff; }
+    .badge-info { background: rgba(35, 197, 255, 0.16); color: #0991c7; }
+    .badge-success { background: rgba(34, 197, 94, 0.14); color: #0f9d58; }
+    .badge-warning { background: rgba(245, 158, 11, 0.15); color: #b45309; }
+    .badge-danger { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
+    .badge-muted { background: #f3f4f6; color: #6b7280; border: 1px solid #e5e7eb; }
+    .tags { display: flex; flex-wrap: wrap; gap: 8px; }
+    .tag { background: #eef2ff; color: #4338ca; padding: 6px 10px; border-radius: 999px; font-size: 12px; }
+    .actions { display: flex; gap: 10px; }
+    .btn { display: inline-flex; align-items: center; justify-content: center; padding: 8px 16px; border-radius: 10px; text-decoration: none; font-size: 13px; font-weight: 600; }
+    .btn-info { background: linear-gradient(135deg, #6366f1, #22d3ee); color: #fff; }
+    .btn-warning { background: linear-gradient(135deg, #f59e0b, #f97316); color: #fff; }
+    .btn-danger { background: linear-gradient(135deg, #ef4444, #f43f5e); color: #fff; }
+    footer { margin-top: 24px; color: #6b7280; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>监控任务中心</h1>
+    <p>集中展示所有关注站点的监测任务与调度状态</p>
+  </header>
+  <main>
+    <table>
+      <thead>
+        <tr>
+          <th>任务名称</th>
+          <th>监测网站</th>
+          <th>关注内容</th>
+          <th>最后执行</th>
+          <th>下一次执行</th>
+          <th>任务状态</th>
+          <th>执行状态</th>
+          <th>最新结果</th>
+          <th>操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="badge badge-primary badge-pill">🛰 自动监控</div>
+            <div style="font-size:16px;font-weight:600;margin-top:4px;">专精特新政策速递</div>
+          </td>
+          <td>国家发展改革委</td>
+          <td>
+            <div class="tags">
+              <span class="tag">产业政策 · 数字化转型</span>
+              <span class="tag">制造业 · 专精特新</span>
+            </div>
+          </td>
+          <td>
+            <div class="badge badge-primary badge-pill">2024-11-30 12:20</div>
+            <div style="font-size:12px;color:#6b7280;margin-top:4px;">UTC+08</div>
+          </td>
+          <td>
+            <div class="badge badge-info badge-pill">12 分钟后</div>
+            <div style="font-size:12px;color:#6b7280;margin-top:4px;">计划于 12:32</div>
+          </td>
+          <td><span class="badge badge-success">🟢 已启用</span></td>
+          <td><span class="badge badge-warning">⏳ 执行中</span></td>
+          <td><span class="badge badge-success">✅ 成功</span></td>
+          <td>
+            <div class="actions">
+              <a class="btn btn-info" href="#">查看</a>
+              <a class="btn btn-warning" href="#">暂停</a>
+              <a class="btn btn-danger" href="#">删除</a>
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <div class="badge badge-primary badge-pill">🛰 自动监控</div>
+            <div style="font-size:16px;font-weight:600;margin-top:4px;">制造业扶持政策</div>
+          </td>
+          <td>工业和信息化部</td>
+          <td>
+            <div class="tags">
+              <span class="tag">补贴申请</span>
+              <span class="tag">项目公示</span>
+            </div>
+          </td>
+          <td>
+            <div class="badge badge-primary badge-pill">2024-11-30 11:55</div>
+            <div style="font-size:12px;color:#6b7280;margin-top:4px;">UTC+08</div>
+          </td>
+          <td>
+            <div class="badge badge-info badge-pill">5 分钟后</div>
+            <div style="font-size:12px;color:#6b7280;margin-top:4px;">计划于 12:25</div>
+          </td>
+          <td><span class="badge badge-success">🟢 已启用</span></td>
+          <td><span class="badge badge-muted">⚙️ 等待调度</span></td>
+          <td><span class="badge badge-danger">❌ 失败</span></td>
+          <td>
+            <div class="actions">
+              <a class="btn btn-info" href="#">查看</a>
+              <a class="btn btn-warning" href="#">暂停</a>
+              <a class="btn btn-danger" href="#">删除</a>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <footer>数据来自演示环境，实际运行时将实时更新。</footer>
+  </main>
+</body>
+</html>

--- a/readme_en.md
+++ b/readme_en.md
@@ -1,0 +1,168 @@
+# Policy Monitor
+
+A configurable policy intelligence monitoring platform that orchestrates website crawling, semantic matching, and alert delivery so teams can track regulatory updates with ease.
+
+## Feature Preview
+
+| Cockpit Overview | Task Orchestration | Result Archive |
+| --- | --- | --- |
+| ![Cockpit mockup](docs/images/dashboard.svg) | ![Task center mockup](docs/images/tasks.svg) | ![Archive mockup](docs/images/results.svg) |
+
+> The illustrations above highlight the primary screens: a real-time cockpit, a task center for fine-grained scheduling, and an archive view for reviewing matched items.
+
+## Key Capabilities
+
+- **Website management** – configure monitored domains, decide whether to follow subpages, and control frequency or proxy usage.
+- **Watch list & taxonomy** – maintain reusable keywords/summaries grouped by category and attach them to multiple tasks.
+- **Task orchestration** – combine sites, watch items, and notification channels, pause/resume jobs, and inspect logs in one place.
+- **Crawling & diff engine** – detect newly published links, extract summaries, and score them via semantic similarity.
+- **Notification channels** – built-in SMTP mailer plus an extendable DingTalk webhook integration.
+- **Operations cockpit** – high-contrast dashboard visualises coverage, running jobs, and live logs at a glance.
+
+## Technical Highlights
+
+- **Flask + SQLAlchemy** foundation for a lightweight yet robust service that is easy to extend.
+- **Pluggable NLP scoring** using `sentence-transformers` (`all-MiniLM-L6-v2`) with graceful fallback to fuzzy matching when unavailable.
+- **In-app scheduler** (`MonitorScheduler`) keeps crawl jobs running in a background thread and hot-reloads proxy configuration.
+- **Observability by design** with structured tables for crawl logs, notifications, and hit records.
+- **Proxy & throttling support** to adapt to sites with strict rate limits.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph UI
+        A[Management UI\nFlask + Jinja2]
+    end
+    subgraph Backend
+        B[Flask routes]
+        C[MonitorScheduler]
+        D[crawler.py]
+        E[nlp.py]
+    end
+    subgraph Services
+        F[(SQLite / RDB)]
+        G[SMTP / DingTalk]
+        H[Proxy manager]
+    end
+
+    A --> B
+    B --> F
+    B --> C
+    C --> D
+    D --> F
+    D --> E
+    D --> G
+    D --> H
+```
+
+## Project Layout
+
+```
+.
+├── app.py               # Flask entry point and routes
+├── crawler.py           # Crawl, diff, and notification logic
+├── database.py          # Database session setup with env override support
+├── email_utils.py       # SMTP & DingTalk helpers
+├── models.py            # SQLAlchemy models
+├── scheduler.py         # Background scheduler
+├── templates/           # Jinja2 templates and cockpit view
+├── docs/images/         # Feature preview illustrations
+├── docs/previews/       # HTML mockups used for screenshots
+├── requirements.txt     # Python dependencies
+└── Dockerfile           # Container build script
+```
+
+## Getting Started (Local Development)
+
+1. **Create a virtual environment & install dependencies**
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate  # On Windows use .venv\Scripts\activate
+   python -m pip install --upgrade pip
+   python -m pip install -r requirements.txt
+   ```
+
+   Install `sentence-transformers` (plus `numpy`/`scipy`) when semantic matching accuracy is required and compatible wheels are available.
+
+2. **Configure outbound notifications**
+
+   Provide SMTP credentials via environment variables or edit `app.py`:
+
+   - `SMTP_HOST`
+   - `SMTP_PORT`
+   - `SMTP_USERNAME`
+   - `SMTP_PASSWORD`
+   - `SMTP_USE_TLS` (optional, defaults to `true`)
+   - `SMTP_SENDER` (optional, defaults to username)
+
+   DingTalk webhook support is available through `send_dingtalk_message` in `email_utils.py`.
+
+3. **Launch the development server**
+
+   ```bash
+   python -m flask --app app run
+   ```
+
+   The first launch provisions the SQLite schema, seeds sample proxies, and starts the scheduler thread.
+
+4. **Open the UI**
+
+   Navigate to [http://localhost:5000](http://localhost:5000) to configure websites, watch items, and monitoring tasks.
+
+## Docker Deployment
+
+1. **Prepare persistent folders** for the database and uploaded artefacts:
+
+   ```bash
+   mkdir -p runtime/data runtime/uploads
+   ```
+
+2. **Build the image**
+
+   ```bash
+   docker build -t policy-monitor:latest .
+   ```
+
+3. **Run the container**
+
+   ```bash
+   docker run -d \
+     --name policy-monitor \
+     -p 5000:5000 \
+     -e FLASK_ENV=production \
+     -e DATABASE_URL=sqlite:////data/data.db \
+     -e SMTP_HOST=smtp.example.com \
+     -e SMTP_PORT=465 \
+     -e SMTP_USERNAME=notify@example.com \
+     -e SMTP_PASSWORD=secret \
+     -e SMTP_USE_TLS=true \
+     -v $(pwd)/runtime/data:/data \
+     -v $(pwd)/runtime/uploads:/uploads \
+     policy-monitor:latest
+   ```
+
+   - `/data` stores the SQLite database (or another DB driver if `DATABASE_URL` is changed).
+   - `/uploads` is reserved for attachments, reports, or snapshots that should live outside the container.
+   - Expose additional ports with extra `-p` flags when required.
+
+4. **Operational tips**
+
+   - View logs with `docker logs -f policy-monitor`.
+   - Rebuild and restart with the same host volumes to upgrade without losing history.
+
+## Operations Notes
+
+- The crawler gracefully falls back to fuzzy matching when `sentence-transformers` cannot be installed.
+- Tune proxy usage and throttle intervals per-website to avoid rate limiting.
+- Back up the `/data` volume regularly to prevent data loss.
+- Extend `email_utils.py` or plug in new notifiers to support Slack, WeChat, or SMS.
+
+## Roadmap Ideas
+
+- Swap the in-process scheduler for APScheduler or Celery for distributed execution.
+- Build a visual rule designer for XPath/JSONPath extraction.
+- Add RBAC, tenancy separation, and audit logging for enterprise scenarios.
+
+Contributions are welcome—feel free to open issues or pull requests!


### PR DESCRIPTION
## Summary
- refresh the Chinese README with feature previews, architecture overview, and Docker deployment guidance
- add an English `readme_en.md` plus illustrative assets for feature previews
- add a Dockerfile and allow overriding the database URL via environment variables for container use

## Testing
- not run (network-restricted environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0eb96623c83209a3f9879710618eb