### PR TITLE
Handle bare domains when building request headers

### DIFF
--- a/request_profiles.py
+++ b/request_profiles.py
@@ -19,14 +19,31 @@ class RequestProfile:
 
     def build_headers(self, url: str) -> dict[str, str]:
         parts = urlsplit(url)
+
+        scheme = parts.scheme or "https"
+        netloc = parts.netloc
+        path = parts.path or "/"
+
+        if not netloc and parts.path:
+            stripped = parts.path.lstrip("/")
+            head, _, tail = stripped.partition("/")
+            if head and "." in head:
+                netloc = head
+                path = "/" + tail if tail else "/"
+
+        hostname = parts.hostname or netloc
+
         mapping = {
-            "scheme": parts.scheme,
-            "netloc": parts.netloc,
-            "hostname": parts.hostname or parts.netloc,
+            "scheme": scheme,
+            "netloc": netloc,
+            "hostname": hostname,
             "url": url,
-            "path": parts.path or "/",
+            "path": path,
         }
-        referer = self.referer_template.format(**mapping)
+
+        referer = ""
+        if netloc:
+            referer = self.referer_template.format(**mapping)
         headers: dict[str, str] = {
             "User-Agent": self.user_agent,
             "Accept-Language": self.accept_language,

--- a/tests/test_request_profiles.py
+++ b/tests/test_request_profiles.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from request_profiles import get_profile_headers
+
+
+def test_request_profiles_normalize_bare_domain() -> None:
+    headers = get_profile_headers("example.com/news/latest")
+
+    referer = headers["Referer"]
+    assert referer.startswith("http")
+    assert "example.com" in referer
+
+
+def test_request_profiles_skip_referer_for_relative_url() -> None:
+    headers = get_profile_headers("/relative/path")
+
+    assert "Referer" not in headers


### PR DESCRIPTION
## Summary
- normalize bare domain URLs when building request headers so referers are well-formed
- avoid emitting referer headers for relative URLs that lack a host
- add regression tests covering bare domains and relative URLs for request profiles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ea0fe9abc88320a470ca04d06d7c62