### PR TITLE
Use Chinese PyPI mirror in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN python -m pip install --upgrade pip \
-    && python -m pip install --no-cache-dir -r requirements.txt
+RUN python -m pip install --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && python -m pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- configure the Dockerfile's pip commands to use the Tsinghua PyPI mirror to avoid timeouts when installing dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecae1a052c83208a5388e31b2bdee1