### PR TITLE
Add Hugging Face mirror fallback for sentence model

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ flowchart LR
 
    如需启用语义匹配模型，确保能够安装 `sentence-transformers` 所需依赖（部分 Python 版本暂未提供预编译轮子）。
 
+   国内环境若无法直接访问 `https://huggingface.co`，可在运行前设置镜像端点，例如：
+
+   ```bash
+   export POLICY_MONITOR_HF_MIRROR=https://hf-mirror.com
+   ```
+
+   加载模型失败时应用会自动尝试使用上述镜像地址（默认即为 `https://hf-mirror.com`）并重试下载。
+
 2. **配置通知渠道**
 
    在环境变量或 `app.py` 中配置以下 SMTP 变量：

--- a/nlp.py
+++ b/nlp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from difflib import SequenceMatcher
 from functools import lru_cache
 from typing import Iterable
@@ -18,6 +19,39 @@ except ImportError:  # pragma: no cover - optional dependency
 
 LOGGER = logging.getLogger(__name__)
 _FALLBACK_NOTICE_EMITTED = False
+_MODEL_NAME = "all-MiniLM-L6-v2"
+_HF_ENDPOINT_ENV = "HF_ENDPOINT"
+_MIRROR_ENV = "POLICY_MONITOR_HF_MIRROR"
+_DEFAULT_MIRROR = "https://hf-mirror.com"
+
+
+def _load_sentence_transformer() -> SentenceTransformer:
+    """Instantiate the configured SentenceTransformer model."""
+
+    return SentenceTransformer(_MODEL_NAME)
+
+
+def _configure_hf_mirror_on_failure(exc: Exception) -> bool:
+    """Set a Hugging Face mirror endpoint if model download failed.
+
+    Returns ``True`` when a mirror endpoint was configured and the caller
+    should retry loading the model, otherwise ``False``.
+    """
+
+    if os.environ.get(_HF_ENDPOINT_ENV):
+        return False
+
+    mirror_endpoint = os.getenv(_MIRROR_ENV, _DEFAULT_MIRROR).strip()
+    if not mirror_endpoint:
+        return False
+
+    message = str(exc).lower()
+    if "huggingface.co" not in message and "connection" not in message:
+        return False
+
+    os.environ[_HF_ENDPOINT_ENV] = mirror_endpoint
+    LOGGER.info("Retrying SentenceTransformer download via mirror %s", mirror_endpoint)
+    return True
 
 
 @lru_cache(maxsize=1)
@@ -26,7 +60,16 @@ def get_model() -> SentenceTransformer | None:
 
     if SentenceTransformer is None:
         return None
-    return SentenceTransformer("all-MiniLM-L6-v2")
+    try:
+        return _load_sentence_transformer()
+    except Exception as exc:  # pragma: no cover - network dependent
+        LOGGER.warning("Failed to load SentenceTransformer model: %s", exc)
+        if _configure_hf_mirror_on_failure(exc):
+            try:
+                return _load_sentence_transformer()
+            except Exception as mirror_exc:  # pragma: no cover - network dependent
+                LOGGER.error("Failed to load model from mirror endpoint: %s", mirror_exc)
+        return None
 
 
 def cosine_similarity(vec_a: "np.ndarray", vec_b: "np.ndarray") -> float:


### PR DESCRIPTION
## Summary
- retry loading the sentence-transformers model via a configurable Hugging Face mirror when the primary endpoint fails
- document how to configure the mirror endpoint for deployments in mainland China

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ef7c7521e4832080e9f9f0671434d2